### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ script:
 
 env:
   # Current version of Fedora
-  - TEST=build_gtk3 TEST_ARGS="fedora 26"
   - TEST=build_gtk3 TEST_ARGS="fedora 27"
   - TEST=build_gtk3 TEST_ARGS="fedora rawhide"
   # Current EPEL/CentOS/RHEL version
   - TEST=build_gtk3 TEST_ARGS="centos 7"
+  # None of the Deb/Ubuntu versions support Sword 1.8+
   # Current version of Ubuntu
-  - TEST=build_gtk3_webkiteditor TEST_ARGS="ubuntu 17.04"
+  #- TEST=build_gtk3_webkiteditor TEST_ARGS="ubuntu 17.10"
   # LTS Ubuntu releases
-  - TEST=build_gtk3_webkiteditor TEST_ARGS="ubuntu 16.04"
+  #- TEST=build_gtk3_webkiteditor TEST_ARGS="ubuntu 16.04"
   # Debian sid
-  - TEST=build_gtk3_webkiteditor TEST_ARGS="debian sid"
+  #- TEST=build_gtk3_webkiteditor TEST_ARGS="debian sid"

--- a/wscript
+++ b/wscript
@@ -376,7 +376,7 @@ def configure(conf):
     env.append_value('ALL_LIBS', 'GTKUPRINT')
 
     conf.check_cfg(package='sword',
-                   args='"sword >= 1.7.3" --cflags --libs',
+                   args='"sword >= 1.8.0" --cflags --libs',
                    uselib_store='SWORD',
                    mandatory=True)
     env.append_value('ALL_LIBS', 'SWORD')


### PR DESCRIPTION
Sword 1.8+ is now required
Fedora 26 will not ship 1.8
None of the Debian or Ubuntu-based distros currently ship Sword 1.8,
either

(CentOS build is currently failing, because I had forgotten to push the Sword 1.8 package for that. But it's in flight and will be available "soon").