### PR TITLE
Add OARS and version tags to appdata

### DIFF
--- a/xiphos.appdata.xml
+++ b/xiphos.appdata.xml
@@ -22,6 +22,10 @@
     <li>Supports Linux and Windows including active support in IRC and mailing lists</li>
   </ul>
  </description>
+ <releases>
+    <release version="4.1.0" date="2018-04-19"/>
+    <release version="4.0.7" date="2017-09-25"/>
+ </releases>
  <screenshots>
   <screenshot type="default">
    <image>https://raw.githubusercontent.com/crosswire/xiphos/master/pixmaps/screenshots/main-window.jpg</image>
@@ -51,4 +55,33 @@
  <url type="homepage">https://github.com/crosswire/xiphos/</url>
  <updatecontact>xiphos-devel@crosswire.org</updatecontact>
  <project_group>GNOME</project_group>
+ <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
 </component>


### PR DESCRIPTION
Adds some more appstream metadata.

I've added basic version tags which help software stores indicate to users what they're about to upgrade to. You can choose to enhance them with real release notes like the contents of https://github.com/crosswire/xiphos/releases if you wish.

OARS is a series of rating tags that lets software stores put location appropriate age ratings. Given what Xiphos ships with I've put a 'there's nothing there' policy in at the moment. You may wish to put in a policy that would seek to rate the contents of the bible as if it was a game:

```  
<content_rating type="oars-1.1">
    <content_attribute id="violence-cartoon">none</content_attribute>
    <content_attribute id="violence-fantasy">none</content_attribute>
    <content_attribute id="violence-realistic">none</content_attribute>
    <content_attribute id="violence-bloodshed">none</content_attribute>
    <content_attribute id="violence-sexual">none</content_attribute>
    <content_attribute id="violence-desecration">none</content_attribute>
    <content_attribute id="violence-slavery">none</content_attribute>
    <content_attribute id="violence-worship">mild</content_attribute>
    <content_attribute id="drugs-alcohol">none</content_attribute>
    <content_attribute id="drugs-narcotics">none</content_attribute>
    <content_attribute id="drugs-tobacco">none</content_attribute>
    <content_attribute id="sex-nudity">none</content_attribute>
    <content_attribute id="sex-themes">mild</content_attribute>
    <content_attribute id="sex-homosexuality">mild</content_attribute>
    <content_attribute id="sex-prostitution">moderate</content_attribute>
    <content_attribute id="sex-adultery">moderate</content_attribute>
    <content_attribute id="sex-appearance">none</content_attribute>
    <content_attribute id="language-profanity">none</content_attribute>
    <content_attribute id="language-humor">none</content_attribute>
    <content_attribute id="language-discrimination">none</content_attribute>
    <content_attribute id="social-chat">none</content_attribute>
    <content_attribute id="social-info">none</content_attribute>
    <content_attribute id="social-audio">none</content_attribute>
    <content_attribute id="social-location">none</content_attribute>
    <content_attribute id="social-contacts">none</content_attribute>
    <content_attribute id="money-purchasing">none</content_attribute>
    <content_attribute id="money-gambling">none</content_attribute>
  </content_rating>
```
Was what I came up with. You may disagree or think about it more with this useful generator: https://hughsie.github.io/oars/