### PR TITLE
avoid deprecated g_type_class_add_private

### DIFF
--- a/src/webkit/wk-html.h
+++ b/src/webkit/wk-html.h
@@ -41,12 +41,12 @@ G_BEGIN_DECLS
 #define WK_HTML_IS_HTML_CLASS(k) (G_TYPE_CHECK_INSTANCE_GET_CLASS((o), WK_TYPE_HTML, WkHtmlClass))
 typedef struct _WkHtml WkHtml;
 typedef struct _WkHtmlClass WkHtmlClass;
-typedef struct _WkHtmlPriv WkHtmlPriv;
+typedef struct _WkHtmlPriv WkHtmlPrivate;
 
 struct _WkHtml
 {
 	WebKitWebView parent;
-	WkHtmlPriv *priv;
+	WkHtmlPrivate *priv;
 };
 struct _WkHtmlPriv
 {

--- a/src/xiphos_html/xiphos_html.h
+++ b/src/xiphos_html/xiphos_html.h
@@ -30,7 +30,7 @@
 
 // Used in places like the ubiquitous _popmenu_requested_cb
 typedef WkHtml XiphosHtml;
-typedef WkHtmlPriv XiphosHtmlPriv;
+typedef WkHtmlPrivate XiphosHtmlPriv;
 
 // Other layers of compatibility - pulled from display_info.c and other places
 #define XIPHOS_HTML WK_HTML
@@ -47,7 +47,7 @@ typedef WkHtmlPriv XiphosHtmlPriv;
 #define XIPHOS_HTML_INITIALIZE wk_html_initialize
 
 #define XIPHOS_TYPE_HTML WK_TYPE_HTML
-#define XIPHOS_HTML_GET_PRIVATE(object) (G_TYPE_INSTANCE_GET_PRIVATE((object), WK_TYPE_HTML, WkHtmlPriv))
+#define XIPHOS_HTML_GET_PRIVATE(object) (G_TYPE_INSTANCE_GET_PRIVATE((object), WK_TYPE_HTML, WkHtmlPrivate))
 
 XiphosHtml *xiphos_html_new(DIALOG_DATA *dialog, gboolean is_dialog,
 			    gint pane);


### PR DESCRIPTION
Fix this build warning:
https://travis-ci.org/crosswire/xiphos/jobs/536165044#L2177
```
[ 20%] Building C object src/webkit/CMakeFiles/webkit.dir/wk-html.c.o
/rootdir/src/webkit/wk-html.c: In function ‘html_class_init’:
/rootdir/src/webkit/wk-html.c:258:2: warning: ‘g_type_class_add_private’ is deprecated [-Wdeprecated-declarations]
  g_type_class_add_private(klass, sizeof(WkHtmlPriv));
  ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/gobject/gobject.h:24,
                 from /usr/include/glib-2.0/gobject/gbinding.h:29,
                 from /usr/include/glib-2.0/glib-object.h:23,
                 from /usr/include/glib-2.0/gio/gioenums.h:28,
                 from /usr/include/glib-2.0/gio/giotypes.h:28,
                 from /usr/include/glib-2.0/gio/gio.h:26,
                 from /rootdir/src/webkit/wk-html.c:25:
/usr/include/glib-2.0/gobject/gtype.h:1303:10: note: declared here
 void     g_type_class_add_private       (gpointer                    g_class,
          ^~~~~~~~~~~~~~~~~~~~~~~~
[ 21%] Building C object src/webkit/CMakeFiles/webkit.dir/marshal.c.o
```