### PR TITLE
fix #919 - disabled status bar reappeared when launching program

### DIFF
--- a/src/gtk/main_window.c
+++ b/src/gtk/main_window.c
@@ -1152,9 +1152,6 @@ void create_mainwindow(void)
 
 	// Statusbar
 	widgets.appbar = gtk_statusbar_new();
-	if (settings.statusbar) {
-		gtk_widget_show(widgets.appbar);
-	}
 
 #ifndef USE_GTK_3
 	gtk_statusbar_set_has_resize_grip(GTK_STATUSBAR(widgets.appbar), TRUE);
@@ -1167,6 +1164,9 @@ void create_mainwindow(void)
 
 	gtk_window_set_default_size((GtkWindow *)widgets.app, settings.gs_width, settings.gs_height);
 	gtk_widget_show_all(widgets.app);
+
+	if (settings.statusbar != 1)
+		gtk_widget_hide(widgets.appbar);
 
 	/* must connect signals *after* instantiating window above, */
 	/* immediately above, otherwise window creation induces */


### PR DESCRIPTION
Even when the status bar was chosen as disabled in the preference menu (and unchecked), it reappeared with every new launch of the program. For me it is fixed now (this is my first commit on Github).