### PR TITLE
remove gconf-2.0 from xiphos (after CMake)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ requires:
     - appstream-glib
     - autoconf
     - automake
-    - gconf
     - cmake
     - dbus-glib
     - docbook-utils
@@ -66,7 +65,6 @@ requires:
     - intltool
     - itstool
     - libdbus-glib-1-dev
-    - libgconf2-dev
     - libglade2-dev
     - libgsf-1-dev
     - libenchant-dev
@@ -89,7 +87,6 @@ requires:
     - dbus-glib-devel
     - desktop-file-utils
     - gcc-c++
-    - gconfmm26-devel
     - gtk3-devel
     - gtkhtml3-devel
     - intltool
@@ -116,7 +113,6 @@ requires:
     - libdbus-glib-1-dev
     - libenchant-dev
     - libgail-3-dev
-    - libgconfmm-2.6-dev
     - libglade2-dev
     - libgsf-1-dev
     - libgtk-3-dev

--- a/cmake/XiphosDependencies.cmake
+++ b/cmake/XiphosDependencies.cmake
@@ -86,7 +86,6 @@ pkg_check_modules(Gnome REQUIRED IMPORTED_TARGET
   "gobject-2.0"
   "libsoup-2.4"
   "pango"
-  "gconf-2.0"
   "libgsf-1>=1.14"
   "libxml-2.0>=2.7.8"
   )

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -4,13 +4,6 @@
 void gui_init(int argc, char *argv[]);
 void gui_main(void);
 
-#ifndef WIN32
-#include <gconf/gconf-client.h>
-void gconf_setup(void);
-#endif
-
-#define GS_GCONF_MAX 6
-
 #ifdef DEBUG
 
 gchar *XI_g_strdup_printf(const char *filename,


### PR DESCRIPTION
We should finally push this issue to some resolution, so that all Linux distros are not carrying this patch.

Fixes #918