### PR TITLE
Remove specific handling of NASB lexica

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-02-02 Greg Hellings <greg.hellings@gmail.com>
+
+	* Remove NASB unique lexica handling
+
 2019-05-10 Dominique Corbex <domcox@users.sf.net>
 
 	* remove Waf

--- a/src/main/module_dialogs.cc
+++ b/src/main/module_dialogs.cc
@@ -1084,18 +1084,10 @@ static gint show_strongs(DIALOG_DATA *t, const gchar *type,
 {
 	const gchar *modbuf = NULL;
 
-	if (!strncmp(t->mod_name, "NASB", 4)) {
-		if (!strcmp(type, "Greek"))
-			modbuf = "NASGreek";
-		else
-			modbuf = "NASHebrew";
-
-	} else {
-		if (!strcmp(type, "Greek"))
-			modbuf = settings.lex_greek;
-		else if (!strcmp(type, "Hebrew"))
-			modbuf = settings.lex_hebrew;
-	}
+	if (!strcmp(type, "Greek"))
+		modbuf = settings.lex_greek;
+	else if (!strcmp(type, "Hebrew"))
+		modbuf = settings.lex_hebrew;
 
 	if (clicked) {
 		static GtkWidget *dlg;

--- a/src/main/url.cc
+++ b/src/main/url.cc
@@ -364,20 +364,13 @@ static gint show_strongs(const gchar *stype, const gchar *svalue,
 {
 	const gchar *modbuf = NULL;
 
-	if (!strncmp(settings.MainWindowModule, "NASB", 4)) {
+	if (stype && (*stype != '\0')) {
 		if (!strcmp(stype, "Greek"))
-			modbuf = "NASGreek";
+			modbuf = settings.lex_greek;
 		else
-			modbuf = "NASHebrew";
-	} else {
-		if (stype && (*stype != '\0')) {
-			if (!strcmp(stype, "Greek"))
-				modbuf = settings.lex_greek;
-			else
-				modbuf = settings.lex_hebrew;
-		} else
-			modbuf = "InvStrongsRealGreek";
-	}
+			modbuf = settings.lex_hebrew;
+	} else
+		modbuf = "InvStrongsRealGreek";
 
 	if (clicked) {
 		main_display_dictionary(modbuf, (gchar *)svalue);


### PR DESCRIPTION
Removes the handling of NASB lexica that was left from earlier plans to
have NASHebrew and NASGreek as companion lexica for the NASB module.
Since those do not exist and are certainly not force-installed, we
should remove them from the code