### PR TITLE
Fix up release builds and process:

### DIFF
--- a/.ci-build.yml
+++ b/.ci-build.yml
@@ -133,7 +133,8 @@ variables:
 before_scripts:
   - |
     START_DIR="$(pwd)"
-    WORK_DIR="${TEMP}"
+    WORK_DIR="/dep_build"
+    mkdir -p "${WORK_DIR}"
     if [ "${DISTRO_NAME}" == "archlinux" ];then
         cd "${WORK_DIR}"
         id -u aur_install &>/dev/null || useradd -r -m -U -G wheel -k /dev/null aur_install
@@ -193,13 +194,3 @@ build_scripts:
     cmake -B build -DCMAKE_INSTALL_PREFIX=/usr -DGTKHTML=ON -DCMAKE_MAKE_PROGRAM=/usr/bin/make .
     make -C build -j$(nproc)
     make -C build mhelp package_source
-    if [ "${DISTRO_NAME}" == "fedora" ]; then
-        (cd build && cpack -G RPM)
-        echo "::set-output name=artifact::$(ls build/*.rpm)"
-    elif [ "${DISTRO_NAME}" == "ubuntu" ]; then
-        (cd build && cpack -G DEB)
-        echo "::set-output name=artifact::$(ls build/*.deb)"
-    elif [ "${DISTRO_NAME}" == "archlinux" ]; then
-        (cd build && cpack -G TGZ)
-        echo "::set-output name=artifact::$(ls build/*.tar.gz)"
-    fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -17,23 +17,22 @@ jobs:
       - name: checkout Xiphos
         uses: actions/checkout@v2
         with:
-          path: xiphos
           fetch-depth: 0
       - name: fetch history
         run: |
-          cd xiphos && git fetch origin +refs/tags/*:refs/tags/*
+          git fetch origin +refs/tags/*:refs/tags/*
       - name: build windows targets
         shell: bash
         id: build
         run: |
           set -ex -o pipefail
-          docker run -i --rm -v "$(pwd):/source" fedora:30 /source/xiphos/win32/xc-xiphos-win.sh ${{ matrix.version }}
-          echo "::set-output name=artifact::$(ls xiphos/*.exe)"
+          docker build -t xiphos win32
+          docker run -i --rm -v "$(pwd):/source" xiphos ${{ matrix.version }}
       - name: upload artifact
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
-          name: packages
-          path: ${{ steps.build.outputs.artifact }}
+          name: windows-installers
+          path: "*.exe"
 
   build_linux:
     runs-on: ubuntu-latest
@@ -69,12 +68,16 @@ jobs:
           python docker-build --name ${{ matrix.distro }} -vvvv --config .ci-build.yml --build scripts
         env:
           TEMP: ${{ runner.temp }}
-      - name: upload source artifact
-        uses: actions/upload-artifact@master
-        if: steps.build.outputs.artifact
+      - name: upload source tarball
+        uses: actions/upload-artifact@v2
         with:
-          name: packages
-          path: ${{ steps.build.outputs.artifact }}
+          name: source
+          path: build/*.tar.gz
+      - name: upload source zipfile
+        uses: actions/upload-artifact@v2
+        with:
+          name: source
+          path: build/*.tar.gz
 
   deploy:
     needs:
@@ -83,21 +86,22 @@ jobs:
     if: contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@master
-        with:
-          name: packages
+      - name: download all the artifacts
+        uses: actions/download-artifact@v2
       - name: prepare for release
         id: release
         run: |
           set -ex
-          cd packages
+          ls -R
+          cd source
           gunzip -k *.tar.gz
           xz *.tar
+          cd ..
           echo ::set-output name=tag::${GITHUB_REF#refs/tags/}
       - name: create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@v1.6.1
         with:
-          artifacts: packages/*
+          artifacts: source/*,windows-installers/*
           allowUpdates: true
           name: Release ${{ steps.release.outputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/cpack/CMakeLists.txt
+++ b/cpack/CMakeLists.txt
@@ -150,10 +150,13 @@ set (CPACK_SOURCE_IGNORE_FILES
   "/.bzrrules"
   "/.git/"
   "/.gitignore"
+  "/.github"
   "/.bzrignore/"
   "/.bzrrules/"
   "/.clang-format"
-  "/.travis.yml"
+  "/.ci-build.yml"
+  "/xiphos-${CPACK_PACKAGE_VERSION}-win32.exe"
+  "/xiphos-${CPACK_PACKAGE_VERSION}-win64.exe"
   )
 
 

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -59,9 +59,9 @@ if (WIN32)
       DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT binaries
       )
-  elseif (EXISTS ${CMAKE_FIND_ROOT_PATH}/lib/libbiblesync.dll)
+  elseif (EXISTS ${CMAKE_FIND_ROOT_PATH}/bin/libbiblesync.dll)
     install(FILES
-      ${SYS_ROOT_LIB}/libbiblesync.dll
+      ${SYS_ROOT_BIN}/libbiblesync.dll
       DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT binaries
       )
@@ -196,7 +196,6 @@ if (WIN32)
     ${SYS_ROOT_BIN}/libpangowin32-1.0-0.dll
     ${SYS_ROOT_BIN}/libatk-1.0-0.dll
     ${SYS_ROOT_BIN}/libxml2-2.dll
-    ${SYS_ROOT_BIN}/libgsf-1-114.dll
     ${SYS_ROOT_BIN}/libbz2-1.dll
     ${SYS_ROOT_BIN}/libgthread-2.0-0.dll
     ${SYS_ROOT_BIN}/libgnurx-0.dll

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -1,0 +1,14 @@
+FROM fedora:30
+
+VOLUME /source
+
+# Installs dependencies once and for all
+RUN dnf -y update --refresh && \
+    dnf -y install cmake git fpc gettext glib2-devel itstool libxslt make yelp-tools zip && \
+    dnf -y install mingw32-biblesync mingw32-gettext mingw32-sword mingw32-minizip mingw32-libglade2 mingw32-webkitgtk mingw32-gtk3 mingw32-libtiff mingw32-libidn mingw32-gdb mingw32-nsis mingw32-dbus-glib && \
+    dnf -y install mingw64-biblesync mingw64-gettext mingw64-sword mingw64-minizip mingw64-libglade2 mingw64-webkitgtk mingw64-gtk3 mingw64-libtiff mingw64-libidn mingw64-gdb mingw32-nsis mingw64-dbus-glib && \
+    dnf clean all
+
+ENTRYPOINT ["/bin/bash", "/source/win32/xc-xiphos-win.sh"]
+
+CMD ["-win32", "-win64"]

--- a/win32/WindowsBuildNotes.txt
+++ b/win32/WindowsBuildNotes.txt
@@ -19,7 +19,14 @@ runtime command:
 mkdir win
 cd win
 git clone https://github.com/crosswire/xiphos.git
-docker run --rm -it -v .:/source fedora:30 /source/xihpos/win32/xc-xiphos-win.sh -win32 -win64
+cd xiphos
+docker run --rm -it -v $(pwd):/source greg-hellings/xiphos
+
+If you don't want to use the greg-hellings/xiphos image or it is unavailable
+for some reason, you can build the image yourself locally, first, like this:
+
+docker build -t xiphos win32
+docker run --rm -it -v $(pwd):/source xiphos
 
 Similar behavior can be achieved through a Fedora 30 VM, or using podman, or
 similar.

--- a/win32/xc-xiphos-win.sh
+++ b/win32/xc-xiphos-win.sh
@@ -24,9 +24,10 @@ by running in a VM or in a container with your favorite container environment th
 has sudo installed. Currently it depends on a Fedora 30 environment to do the builds
 and won't work for later versions of Fedora because of missing dependncies. For example:
 
-mkdir src && cd src
 git checkout https://github.com/crosswire/xiphos.git
-docker run -it --rm -v "$(pwd):/source" fedora:30 /source/xiphos/win32/xc-xiphos-win.sh -win32"
+cd xiphos
+docker build -t xiphos win32
+docker run -it --rm -v "$(pwd):/source" xiphos -win32"
 EOF
 }
 
@@ -74,41 +75,7 @@ echo "Build for Windows 32-bit    = $([ "$WIN32" -gt 0 ] && echo 'Yes' || echo '
 echo "Build for Windows 64-bit    = $([ "$WIN64" -gt 0 ] && echo 'Yes' || echo 'No')"
 echo "Xiphos Source directory     = ${XIPHOS_PATH}"
 
-
-
 trap 'exit 1' ERR
-
-# Update packages
-echo '** Upgrading packages on the system:'
-sudo dnf -y upgrade --refresh
-
-
-# Install build tools
-echo '** Installing build tools in the toolbox:'
-sudo dnf -y install cmake git fpc gettext glib2-devel itstool libxslt make yelp-tools zip
-
-
-# Install mingw dependencies
-if [ "$WIN32" -gt '0' ]; then
-    echo '** Installing mingw32 dependencies:'
-    sudo dnf -y install mingw32-gettext mingw32-sword mingw32-minizip mingw32-libgsf mingw32-libglade2 mingw32-webkitgtk mingw32-gtk3 mingw32-libtiff mingw32-libidn mingw32-gdb mingw32-nsis mingw32-dbus-glib
-fi
-if [ "$WIN64" -gt '0' ]; then
-    echo '** Installing mingw64 dependencies:'
-    sudo dnf -y install mingw64-gettext mingw64-sword mingw64-minizip mingw64-libgsf mingw64-libglade2 mingw64-webkitgtk mingw64-gtk3 mingw64-libtiff mingw64-libidn mingw64-gdb mingw32-nsis mingw64-dbus-glib
-fi
-
-
-# Build and install Biblesync with Mingw
-if [ "$WIN32" -gt '0' ]; then
-    echo '** Installing Biblesync 32 bit:'
-    sudo dnf -y install --enablerepo=updates-testing mingw32-biblesync
-fi
-
-if [ "$WIN64" -gt '0' ]; then
-    echo '** Installing Biblesync-64 bit:'
-    sudo dnf -y install --enablerepo=updates-testing mingw64-biblesync
-fi
 
 # Configure && build .EXE
 function do_build {


### PR DESCRIPTION
Pull libbiblesync.dll from system installation location
Install biblesync from Fedora package repos
Remove libgsf, which is no longer needed
Allow building the container image to avoid re-downloading dependencies,
over and over again
Don't include new build files in package
Upload both .tar.gz and .zip files
Don't generate RPM or deb files
Simplify logic for source upload, since Github Actions will detect
duplicates, and only the first file will be accepted
v2 of {upload,download}-artifact actions now has greatly streamlined
tools so we don't have to be so uptight about how things are specified.
Move to using this
Update docs