### PR TITLE
Build with webkit2gtk 4.1 and libsoup3

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -285,7 +285,7 @@ Create a build directory as a sibling of the xiphos directory:
 
 ## 5. Install the required dependencies:
 
-    $ sudo apt-get appstream-util cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libdbus-glib-1-dev libenchant-dev libgail-3-dev libglade2-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.0-dev libxml2-dev libxml2-utils make python-dev swig uuid-dev uuid-runtime yelp-tools xzip
+    $ sudo apt-get appstream-util cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libdbus-glib-1-dev libenchant-dev libgail-3-dev libglade2-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.1-dev libxml2-dev libxml2-utils make python-dev swig uuid-dev uuid-runtime yelp-tools xzip
 
 ## 6. Configuration:
 

--- a/cmake/XiphosDependencies.cmake
+++ b/cmake/XiphosDependencies.cmake
@@ -84,7 +84,7 @@ pkg_check_modules(Gnome REQUIRED IMPORTED_TARGET
   "gdk-pixbuf-2.0"
   "gio-2.0"
   "gobject-2.0"
-  "libsoup-2.4"
+  "libsoup-3.0"
   "pango"
   "minizip"
   "zlib"
@@ -144,7 +144,7 @@ else (GTK2)
     # Gtk+-3.0 + Webkit2 + GtkHtml-editor
      pkg_check_modules(Gtk REQUIRED IMPORTED_TARGET
       "gtk+-3.0"
-      "webkit2gtk-4.0"
+      "webkit2gtk-4.1"
       )
   endif()
 endif (GTK2)


### PR DESCRIPTION
Forwarded from [Debian](https://salsa.debian.org/pkg-crosswire-team/xiphos/-/merge_requests/6):

Debian's webkit2gtk maintainers intend to stop building the 4.0 API soon. The 4.1 API is the same as the 4.0 API except that it uses libsoup3 instead of libsoup2.4.

Fedora has already [stopped](https://fedoraproject.org/wiki/Changes/Remove_webkit2gtk-4.0_API_Version) building the 4.0 API in preparation for the Fedora 40 release in a few months.

libsoup2 -> libsoup3 porting is sometimes [complex](https://gitlab.gnome.org/GNOME/libsoup/-/issues/218). But in this case, I only made a minimal change and I was able to download a Bible translation with Xiphos and things appeared to work ok.