### PR TITLE
Handle tabs more like browsers do

### DIFF
--- a/src/gtk/main_window.c
+++ b/src/gtk/main_window.c
@@ -67,6 +67,7 @@
 /* we must define the categories of #definitions we need. */
 #define XK_MISCELLANY
 #define XK_LATIN1
+#define XK_XKB_KEYS
 #include <X11/keysymdef.h>
 
 WIDGETS widgets;
@@ -795,6 +796,22 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 			on_notebook_main_new_tab_clicked(NULL, NULL);
 		else if (state == GDK_MOD1_MASK) // Alt-T transliteration
 			kbd_toggle_option(true, "Transliteration");
+		break;
+
+	case XK_Tab:
+		if (state == GDK_CONTROL_MASK) // Ctrl-Tab  next tab
+			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL) {
+				gtk_notebook_next_page(GTK_NOTEBOOK(widgets.notebook_main));
+				return TRUE; // Need to prevent Tab from navigating between widgets here
+			}
+		break;
+
+	case XK_ISO_Left_Tab:
+		if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) // Ctrl-Shift-Tab  previous tab
+			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL) {
+				gtk_notebook_prev_page(GTK_NOTEBOOK(widgets.notebook_main));
+				return TRUE; // Need to prevent Shift-Tab from navigating between widgets here
+			}
 		break;
 
 	case XK_z:

--- a/src/gtk/main_window.c
+++ b/src/gtk/main_window.c
@@ -815,12 +815,12 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 		break;
 
 	case XK_Page_Up:
-		if (state == GDK_CONTROL_MASK) {
+		if (state == GDK_CONTROL_MASK) { // Ctrl-PgUp  previous tab
 			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL) {
 				gtk_notebook_prev_page(GTK_NOTEBOOK(widgets.notebook_main));
 				return TRUE; // Prevent from navigating standard/parallel view
 			}
-		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
+		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) { // Ctrl-Shift-PgUp  reorder tab to left
 			gint current_tab_idx = gtk_notebook_get_current_page(GTK_NOTEBOOK(widgets.notebook_main));
 			GtkWidget *current_tab = gtk_notebook_get_nth_page(GTK_NOTEBOOK(widgets.notebook_main), current_tab_idx);
 			if (current_tab_idx != 0) {
@@ -830,11 +830,11 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 		break;
 
 	case XK_Page_Down:
-		if (state == GDK_CONTROL_MASK) {
+		if (state == GDK_CONTROL_MASK) { // Ctrl-PgDown  next tab
 			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL)
 				gtk_notebook_next_page(GTK_NOTEBOOK(widgets.notebook_main));
 			return TRUE; // Prevent from navigating standard/parallel view
-		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
+		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) { // Ctrl-Shift-PgDown  reorder tab to right
 			gint current_tab_idx = gtk_notebook_get_current_page(GTK_NOTEBOOK(widgets.notebook_main));
 			gint n_tabs = gtk_notebook_get_n_pages(GTK_NOTEBOOK(widgets.notebook_main));
 			GtkWidget *current_tab = gtk_notebook_get_nth_page(GTK_NOTEBOOK(widgets.notebook_main), current_tab_idx);

--- a/src/gtk/main_window.c
+++ b/src/gtk/main_window.c
@@ -815,12 +815,7 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 		break;
 
 	case XK_Page_Up:
-		if (state == GDK_CONTROL_MASK) { // Ctrl-PgUp  previous tab
-			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL) {
-				gtk_notebook_prev_page(GTK_NOTEBOOK(widgets.notebook_main));
-				return TRUE; // Prevent from navigating standard/parallel view
-			}
-		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) { // Ctrl-Shift-PgUp  reorder tab to left
+		if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) { // Ctrl-Shift-PgUp  reorder tab to left
 			gint current_tab_idx = gtk_notebook_get_current_page(GTK_NOTEBOOK(widgets.notebook_main));
 			GtkWidget *current_tab = gtk_notebook_get_nth_page(GTK_NOTEBOOK(widgets.notebook_main), current_tab_idx);
 			if (current_tab_idx != 0) {
@@ -830,11 +825,7 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 		break;
 
 	case XK_Page_Down:
-		if (state == GDK_CONTROL_MASK) { // Ctrl-PgDown  next tab
-			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL)
-				gtk_notebook_next_page(GTK_NOTEBOOK(widgets.notebook_main));
-			return TRUE; // Prevent from navigating standard/parallel view
-		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) { // Ctrl-Shift-PgDown  reorder tab to right
+		if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) { // Ctrl-Shift-PgDown  reorder tab to right
 			gint current_tab_idx = gtk_notebook_get_current_page(GTK_NOTEBOOK(widgets.notebook_main));
 			gint n_tabs = gtk_notebook_get_n_pages(GTK_NOTEBOOK(widgets.notebook_main));
 			GtkWidget *current_tab = gtk_notebook_get_nth_page(GTK_NOTEBOOK(widgets.notebook_main), current_tab_idx);

--- a/src/gtk/main_window.c
+++ b/src/gtk/main_window.c
@@ -844,6 +844,14 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 		}
 		break;
 
+	case XK_w:
+		if (state == GDK_CONTROL_MASK) { // Ctrl-W  close current tab
+			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL) {
+				gint pagenum = gtk_notebook_get_current_page(GTK_NOTEBOOK(widgets.notebook_main));
+				gui_close_passage_tab(pagenum);
+			}
+		}
+		break;
 
 	case XK_z:
 	case XK_Z:

--- a/src/gtk/main_window.c
+++ b/src/gtk/main_window.c
@@ -814,6 +814,37 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 			}
 		break;
 
+	case XK_Page_Up:
+		if (state == GDK_CONTROL_MASK) {
+			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL) {
+				gtk_notebook_prev_page(GTK_NOTEBOOK(widgets.notebook_main));
+				return TRUE; // Prevent from navigating standard/parallel view
+			}
+		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
+			gint current_tab_idx = gtk_notebook_get_current_page(GTK_NOTEBOOK(widgets.notebook_main));
+			GtkWidget *current_tab = gtk_notebook_get_nth_page(GTK_NOTEBOOK(widgets.notebook_main), current_tab_idx);
+			if (current_tab_idx != 0) {
+				gtk_notebook_reorder_child(GTK_NOTEBOOK(widgets.notebook_main), current_tab, current_tab_idx - 1);
+			}
+		}
+		break;
+
+	case XK_Page_Down:
+		if (state == GDK_CONTROL_MASK) {
+			if (GTK_NOTEBOOK(widgets.notebook_main) != NULL)
+				gtk_notebook_next_page(GTK_NOTEBOOK(widgets.notebook_main));
+			return TRUE; // Prevent from navigating standard/parallel view
+		} else if (state == (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
+			gint current_tab_idx = gtk_notebook_get_current_page(GTK_NOTEBOOK(widgets.notebook_main));
+			gint n_tabs = gtk_notebook_get_n_pages(GTK_NOTEBOOK(widgets.notebook_main));
+			GtkWidget *current_tab = gtk_notebook_get_nth_page(GTK_NOTEBOOK(widgets.notebook_main), current_tab_idx);
+			if (current_tab_idx < n_tabs - 1) {
+				gtk_notebook_reorder_child(GTK_NOTEBOOK(widgets.notebook_main), current_tab, current_tab_idx + 1);
+			}
+		}
+		break;
+
+
 	case XK_z:
 	case XK_Z:
 		if (state == GDK_MOD1_MASK) // Alt-Z  open personal commentary

--- a/src/gtk/tabbed_browser.c
+++ b/src/gtk/tabbed_browser.c
@@ -67,7 +67,6 @@ void set_current_tab(PASSAGE_TAB_INFO *pt);
 gboolean stop_refresh = FALSE;
 gboolean change_tabs_no_redisplay = FALSE;
 gboolean closing_tab = FALSE;
-gboolean tab_reorder_out_of_sync = FALSE;
 
 GList *passage_list;
 
@@ -993,7 +992,8 @@ void gui_notebook_main_page_reordered(GtkNotebook *notebook,
 				      guint page_num,
 				      GList **tl)
 {
-	if (tab_reorder_out_of_sync) {
+	static gboolean tab_order_out_of_sync = FALSE;
+	if (tab_order_out_of_sync) {
 		return;
 	}
 
@@ -1018,7 +1018,7 @@ void gui_notebook_main_page_reordered(GtkNotebook *notebook,
 		g_warning("Couldn't find reordered page in passage_list!\
 `widgets.notebook_main` and `passage_list` might be out of sync! Refusing to\
 persist further tab rearrangements.\n");
-		tab_reorder_out_of_sync = true;
+		tab_order_out_of_sync = true;
 		return;
 	}
 

--- a/src/gtk/tabbed_browser.c
+++ b/src/gtk/tabbed_browser.c
@@ -299,6 +299,9 @@ void notebook_main_add_page(PASSAGE_TAB_INFO *tbinf)
 	gtk_notebook_append_page(GTK_NOTEBOOK(widgets.notebook_main),
 				 tbinf->page_widget, tab_widget);
 
+	gtk_notebook_set_tab_reorderable(GTK_NOTEBOOK(widgets.notebook_main),
+					 tbinf->page_widget, TRUE);
+
 	gtk_notebook_set_menu_label_text(GTK_NOTEBOOK(widgets.notebook_main),
 					 tbinf->page_widget, str->str);
 

--- a/src/gtk/tabbed_browser.c
+++ b/src/gtk/tabbed_browser.c
@@ -194,13 +194,9 @@ void set_current_tab(PASSAGE_TAB_INFO *pt)
 	if (stop_refresh)
 		return;
 
-	if (!closing_tab && ot != NULL && ot->button_close != NULL) {
-		gtk_widget_set_sensitive(ot->button_close, FALSE);
-	}
 	cur_passage_tab = pt;
 	if (pt != NULL && pt->button_close != NULL) {
 		//main_update_tab_history_menu((PASSAGE_TAB_INFO*)pt);
-		gtk_widget_set_sensitive(pt->button_close, TRUE);
 
 		/* adopt panel shows from passage tab memory. */
 		settings.showtexts = pt->showtexts;
@@ -885,7 +881,6 @@ static GtkWidget *tab_widget_new(PASSAGE_TAB_INFO *tbinf,
 	gtk_widget_size_request(tbinf->button_close, &r);
 #endif
 
-	gtk_widget_set_sensitive(tbinf->button_close, FALSE);
 	gtk_widget_show(tbinf->button_close);
 	tbinf->tab_label = GTK_LABEL(gtk_label_new(label_text));
 	gtk_widget_show(GTK_WIDGET(tbinf->tab_label));

--- a/src/gtk/tabbed_browser.c
+++ b/src/gtk/tabbed_browser.c
@@ -997,6 +997,8 @@ void gui_notebook_main_page_reordered(GtkNotebook *notebook,
 		return;
 	}
 
+	guint new_index = page_num;
+
 	// Get index of passage_list entry that matches `page`
 	GList *passage_list = *tl;
 	PASSAGE_TAB_INFO *pt = passage_list->data;
@@ -1024,11 +1026,26 @@ persist further tab rearrangements.\n");
 
 	// Swap pointers inside of passage_list to match swap
 	// performed by notebook.
-	GList *old_pt = g_list_nth(passage_list, old_index);
-	GList *new_pt = g_list_nth(passage_list, page_num);
-	gpointer tmp = old_pt->data;
-	old_pt->data = new_pt->data;
-	new_pt->data = tmp;
+	if (old_index == new_index) { return; }
+
+	bool shifting_right = false;
+	if (new_index > old_index) {
+		shifting_right = true;
+	}
+
+	GList *sibling = NULL;
+	if (new_index < g_list_length(passage_list) - 1) {
+		sibling = g_list_nth(passage_list, new_index);
+		if (shifting_right) {
+			sibling = sibling->next;
+		}
+	}
+
+	GList *link = g_list_nth(passage_list, old_index);
+	passage_list = g_list_remove_link(passage_list, link);
+	passage_list = g_list_insert_before_link(passage_list, sibling, link);
+
+	*tl = passage_list;
 }
 
 /******************************************************************************

--- a/src/gtk/tabbed_browser.c
+++ b/src/gtk/tabbed_browser.c
@@ -800,8 +800,8 @@ void gui_load_tabs(const gchar *filename)
  *   #include "tabbed_browser.h"
  *
  *   void on_notebook_main_tab_clicked(GtkWidget *self,
-				       GdkEventButton *event,
-				       gpointer user_data)
+ *				       GdkEventButton *event,
+ *				       gpointer user_data)
  *
  * Description
  *   Handle click events for tabs

--- a/src/gtk/tabbed_browser.c
+++ b/src/gtk/tabbed_browser.c
@@ -848,7 +848,7 @@ static gboolean on_notebook_main_tab_clicked(GtkWidget *self,
  *
  *
  * Return value
- *   void
+ *   gpointer
  */
 
 static void on_notebook_main_close_page(GtkButton *button,

--- a/src/gui/tabbed_browser.h
+++ b/src/gui/tabbed_browser.h
@@ -104,6 +104,10 @@ void gui_recompute_shows(gboolean flush);
 void gui_recompute_view_menu_choices(void);
 void setup_book_editor_tab(PASSAGE_TAB_INFO *pt);
 GString *pick_tab_label(PASSAGE_TAB_INFO *pt);
+void gui_notebook_main_page_reordered(GtkNotebook *notebook,
+				      gpointer page,
+				      guint page_num,
+				      GList **tl);
 #ifdef USE_GTK_3
 void gui_notebook_main_switch_page(GtkNotebook *notebook,
 				   gpointer arg1, gint page_num,

--- a/src/gui/tabbed_browser.h
+++ b/src/gui/tabbed_browser.h
@@ -32,6 +32,7 @@ struct _passage_tab_info
 {
 	GtkWidget *page_widget;
 	GtkLabel *tab_label;
+	GtkEventBox *tab_label_eventbox;
 	GtkWidget *button_close;
 	GtkWidget *editor;
 	GtkWidget *paratab;


### PR DESCRIPTION
This PR is based off of issue #1147.

In short, the purpose of this PR is to add various shortcuts/behaviors that make the tab system work a bit more as someone would expect coming from modern browsers. For a full list of changes, please see the original issue or refer to the names of these commits.

I ensured that formatting and code styles are as similar as the rest of the project as possible. Thank you for considering my contribution!


Closes #1147