### PR TITLE
Add .editorconfig for indents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{c,cc,cpp,cxx,h,hh,hpp,hxx}]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
This file is really basic; all it says is that indents for all C-related files should be **tabs** of **size 8**. Without this, there's really no way to have global editor options that differ and still maintain the project's preferred formatting style (unless we add a bunch of .gitignores, more about that below if you feel like reading).

<details>
<summary>Brief explanation of <code>.editorconfig</code></summary>

Many people and projects have different preferences for how their code should be formatted. Some prefer spaces, some prefer tabs, some prefer 2, 4, 8-long indents, or anywhere in-between. Because of this, many editors allow the developer to add an editor-specific config inside the project (e.g. ".vscode/settings.json") to specify formatting for that particular project (or workspace) so you don't have to change those options globally. The problem is, either these configuration directories are included in the repo and contain other personal editor options, cluttering the repo for everyone, or they're .gitignore'd out of the repo, at which point no one can tell their editor to use these configurations unless they change their global options or remember to leave it out of git every commit they make.

One solution is [EditorConfig](https://editorconfig.org/). This is a file specifically to be included in the repo and will usually do nothing more than tell all editors universally what the formatting preferences are for the project. Many editors support it, which means no more uniquely named editor dotfile configs, and no need to change your entire user config to match every project you work on.
</details>