### PR TITLE
Fix appdata file

### DIFF
--- a/desktop/xiphos.appdata.xml
+++ b/desktop/xiphos.appdata.xml
@@ -5,6 +5,7 @@
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-2.0+</project_license>
  <name>Xiphos</name>
+ <developer_name>The Xiphos Developer Team</developer_name>
  <summary>Bible Study Guide</summary>
  <launchable type="desktop-id">xiphos.desktop</launchable>
  <description>
@@ -58,7 +59,6 @@
   </screenshot>
  </screenshots>
  <url type="homepage">https://github.com/crosswire/xiphos/</url>
- <updatecontact>xiphos-devel@crosswire.org</updatecontact>
- <project_group>GNOME</project_group>
+ <update_contact>xiphos-devel@crosswire.org</update_contact>
  <translation type="gettext">Xiphos</translation>
 </component>


### PR DESCRIPTION
Fixes three remaining AppStream errors:

"unknown-tag updatecontact" (should be update_contact),
"cid-missing-affiliation-gnome" (this is reserved only for apps by GNOME developers),
"appstream-missing-developer-name" (is required).