### PR TITLE
update INSTALL.md to reflect new build process for Debian/Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -250,50 +250,17 @@ Create a build directory as a sibling of the xiphos directory:
 Build Xiphos On *Debian*, *Ubuntu*, or *Linux Mint*:
 ===================================================
 
-## 1. Install GTKHtml
-
-    $ curl -Ls -o gtkhtml-4.10.0.tar.xz https://download.gnome.org/sources/gtkhtml/4.10/gtkhtml-4.10.0.tar.xz
-    $ tar xf gtkhtml-4.10.0.tar.xz
-    $ cd gtkhtml-4.10.0
-    $ ./configure --prefix=/usr --sysconfdir=/etc --libexecdir=/usr/lib/gtkhtml4 --localstatedir=/var --disable-static
-    $ make -j2
-    $ make install
-
-## 2. Install Biblesync
-
-    $ curl -Ls -o biblesync-1.2.0.tar.gz https://github.com/karlkleinpaste/biblesync/archive/1.2.0.tar.gz
-    $ tar xf biblesync-1.2.0.tar.gz
-    $ cd biblesync-1.2.0
-    $ mkdir -p build
-    $ cd build
-    $ cmake -DBUILD_SHARED_LIBS=TRUE -DCMAKE_INSTALL_PREFIX=/usr -DLIBDIR=/usr/lib ..
-    $ make -j2
-    $ make install
-
-## 3. Clone git
+## 1. Clone git
 
     $ git https://github.com/crosswire/xiphos.git
 
-## 4. Create and enter the build directory
+## 2. Install the required dependencies:
 
-Create a build directory as a sibling of the xiphos directory:
+    $ sudo apt-get install appstream-util cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libbiblesync-dev libdbus-glib-1-dev libenchant-2-dev libgail-3-dev libglade2-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.1-dev libxml2-dev libxml2-utils make python3-dev swig uuid-dev uuid-runtime yelp-tools xzip
 
-    $ mkdir build
-    $ ls
-	build xiphos
-	$ cd build
+## 3. Build and install:
 
-## 5. Install the required dependencies:
-
-    $ sudo apt-get appstream-util cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libdbus-glib-1-dev libenchant-2-dev libgail-3-dev libglade2-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.1-dev libxml2-dev libxml2-utils make python3-dev swig uuid-dev uuid-runtime yelp-tools xzip
-
-## 6. Configuration:
-
-    $ cmake -DCMAKE_INSTALL_PREFIX=/usr -DWEBKIT1=ON ../xiphos
-
-## 7. Build and install
-
-    $ make -j$(nproc) && make install
+    $ cmake -B build -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_MAKE_PROGRAM=make .
 
 
 Make packages with CMake


### PR DESCRIPTION
Fix the instructions for building in INSTALL.md to reflect new build process introduced with changes from #1198

This only changes the instructions under Debian/Ubuntu distros, others likely need updated too.