### PR TITLE
Dialog alert user if studypad is not supported on their platform

### DIFF
--- a/src/editor/webkit_editor.c
+++ b/src/editor/webkit_editor.c
@@ -33,6 +33,7 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include "editor/webkit_editor.h"
+#include "gui/dialog.h"
 
 gint editor_create_new(const gchar *filename, const gchar *key, gint editor_type)
 {

--- a/src/editor/webkit_editor.c
+++ b/src/editor/webkit_editor.c
@@ -34,7 +34,10 @@
 #include <glib/gi18n.h>
 #include "editor/webkit_editor.h"
 
-gint editor_create_new(const gchar *filename, const gchar *key, gint editor_type) {}
+gint editor_create_new(const gchar *filename, const gchar *key, gint editor_type)
+{
+	gui_generic_warning(_("The Studypad is disabled on this platform due to missing dependencies. We hope to re-enable it in a future release."));
+}
 void editor_maybe_save_all(void) {}
 void editor_load_note(EDITOR *e, const gchar *module_name, const gchar *key) {}
 void editor_sync_with_main(void) {}


### PR DESCRIPTION
As you know I am new to contributing to Xiphos so if there's anything I've done wrong do let me know!

This simply alerts the user with a GUI dialogue box that their version of Xiphos does not support the Studypad.