### PR TITLE
Only skip building with WK2 editor

### DIFF
--- a/src/editor/editor.c
+++ b/src/editor/editor.c
@@ -1145,7 +1145,7 @@ void create_editor_window(GtkWidget *scrollwindow, EDITOR *e)
 		webkit_web_view_load_string((WebKitWebView *)
 					    e->html_widget,
 					    text,
-					    "application/xhtml+xml", "utf_8",
+					    "text/html", "utf_8",
 					    "file://");
 	}
 	if (text)

--- a/src/editor/editor.c
+++ b/src/editor/editor.c
@@ -23,7 +23,7 @@
 #include <config.h>
 #endif
 
-#ifdef USE_WEBKIT_EDITOR
+#if defined(USE_WEBKIT_EDITOR) && defined(USE_WEBKIT2)
 
 /*
  * currently stubbed in webkit_editor.c.

--- a/src/editor/webkit_editor.c
+++ b/src/editor/webkit_editor.c
@@ -354,7 +354,7 @@ action_delete_item_activate_cb(GtkWidget *widget, EDITOR *e)
 			webkit_web_view_load_string((WebKitWebView *)
 						    e->html_widget,
 						    text,
-						    "application/xhtml+xml", "utf_8",
+						    "text/html", "utf_8",
 						    "file://");
 		}
 		if (text)
@@ -1046,7 +1046,7 @@ void editor_load_book(EDITOR *e)
 		webkit_web_view_load_string((WebKitWebView *)
 					    e->html_widget,
 					    text,
-					    "application/xhtml+xml", "utf_8",
+					    "text/html", "utf_8",
 					    "file://");
 	}
 
@@ -1134,7 +1134,7 @@ editor_load_note(EDITOR *e, const gchar *module_name, const gchar *key)
 		webkit_web_view_load_string((WebKitWebView *)
 					    e->html_widget,
 					    text,
-					    "application/xhtml+xml", "utf_8",
+					    "text/html", "utf_8",
 					    "file://");
 	}
 

--- a/src/editor/webkit_editor.c
+++ b/src/editor/webkit_editor.c
@@ -21,7 +21,7 @@
 
 #include <config.h>
 
-#ifdef USE_WEBKIT_EDITOR
+#if defined(USE_WEBKIT_EDITOR) && defined(USE_WEBKIT2)
 
 /* stubs for disabled editor */
 
@@ -45,7 +45,7 @@ void editor_sync_with_main(void) {}
 void editor_save_book(EDITOR *e) {}
 void editor_load_book(EDITOR *e) {}
 
-#else  /* !USE_WEBKIT_EDITOR */
+#else  /* !USE_WEBKIT_EDITOR || !USE_WEBKIT2 */
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -1453,4 +1453,4 @@ void editor_maybe_save_all(void)
 	}
 }
 
-#endif /* USE_WEBKIT_EDITOR */
+#endif /* defined(USE_WEBKIT_EDITOR) && defined(USE_WEBKIT2) */


### PR DESCRIPTION
Restores editor functionality for systems using WebKit1 API (most notably Windows builds).

Maintains the not-supported error message when looking at WebKit2 editor builds