### PR TITLE
Build with ICU correctly

### DIFF
--- a/win32/build_sword.sh
+++ b/win32/build_sword.sh
@@ -9,6 +9,7 @@ tar xzf sword.tar.gz
 cd sword-1.9.0
 # It confuses gcc when you have this
 sed -i configure.ac -e 's#-no-undefined##'
+sed -i configure.ac -e 's#with_icu=no#PKG_CHECK_MODULES([ICU],[icu-uc icu-io icu-i18n],false,true)\nAM_CFLAGS="$AM_CFLAGS -D_ICU_"\nAM_CXXFLAGS="$AM_CXXFLAGS -D_ICU_"\nLIBS="$LIBS $ICU_LIBS"#'
 # But ld NEEDS to have it for the shared library
 sed -i lib/Makefile.am -E -e 's#libsword_la_LDFLAGS =(.*)#libsword_la_LDFLAGS = -no-undefined \1#'
 autoreconf
@@ -23,7 +24,7 @@ function build_sword {
     export RANLIB="${arch}-w64-mingw32-ranlib"
     export STRIP="${arch}-w64-mingw32-strip"
     export LD="${arch}-w64-mingw32-ld"
-    export CFLAGS="-I/usr/${arch}-w64-mingw32/sys-root/mingw/include -I$(pwd)/../sword-1.9.0/include -D_ICUSWORD_"
+    export CFLAGS="-I/usr/${arch}-w64-mingw32/sys-root/mingw/include -I$(pwd)/../sword-1.9.0/include"
     export CXXFLAGS="${CXXFLAGS} ${CFLAGS}"
     export LDFLAGS="-L/usr/${arch}-w64-mingw32/sys-root/mingw/lib"
     export PATH="/usr/${arch}-w64-mingw32/sys-root/mingw/bin:${PATH}"
@@ -33,6 +34,7 @@ function build_sword {
     ../sword-1.9.0/configure \
         --enable-shared \
         --disable-static \
+        --with-icusword \
         --host=${arch}-w64-mingw32 \
         --target=${arch}-w64-mingw32 \
         --build=${arch}-linux-gnu \
@@ -50,9 +52,8 @@ function build_sword {
         --sharedstatedir=/usr/${arch}-w64-mingw32/sys-root/mingw/com \
         --mandir=/usr/${arch}-w64-mingw32/sys-root/mingw/share/man \
         --infodir=/usr/${arch}-w64-mingw32/sys-root/mingw/share/info \
-        --with-clucene=/usr/${arch}-w64-mingw32/sys-root/mingw \
-        --with-icu=/usr/${arch}-w64-mingw32/sys-root/mingw || cat config.log
-    make -j10
+        --with-clucene=/usr/${arch}-w64-mingw32/sys-root/mingw || cat config.log
+    make -j10 || cat config.log
     make install
     mv "utilities/.libs/addld.exe" "/usr/${arch}-w64-mingw32/sys-root/mingw/bin/addld.exe"
     cd ..


### PR DESCRIPTION
Patch configure.ac to use pkg-config for ICU detection Use --with-icusword in configure arguments rather than hard defining it Don't pass weird arguments to --with-icu

Fixes #1227 