### PR TITLE
fix LTO/One Definition Rule violations

### DIFF
--- a/src/main/parallel_view.cc
+++ b/src/main/parallel_view.cc
@@ -83,7 +83,7 @@ SWBuf unknown_parallel = _("Unknown parallel module: ");
  */
 
 BackEnd *backend_p;
-extern gchar *no_content;
+extern const gchar *no_content;
 
 static const gchar *tf2of(int true_false)
 {


### PR DESCRIPTION
>xiphos-4.3.2/src/main/parallel_view.cc:86:15:
>error: ‘no_content’ violates the C++ One Definition Rule [-Werror=odr]
>   86 | extern gchar *no_content;
>      |               ^
>xiphos-4.3.2/src/main/display.cc:88:14: note: ‘no_content’ was previously declared here
>   88 | const gchar *no_content =
>      |              ^