### PR TITLE
Add content-rating and releases to appdata

### DIFF
--- a/desktop/xiphos.appdata.xml
+++ b/desktop/xiphos.appdata.xml
@@ -61,4 +61,10 @@
  <url type="homepage">https://github.com/crosswire/xiphos/</url>
  <update_contact>xiphos-devel@crosswire.org</update_contact>
  <translation type="gettext">Xiphos</translation>
+ <content_rating type="oars-1.1" />
+ <releases>
+   <release version="4.3.2" date="2025-04-10">
+     <url type="details">https://xiphos.org/development/release-notes.html</url>
+   </release>
+ </releases>
 </component>


### PR DESCRIPTION
I know you didn't want this in #898, but Flathub now requires both a content rating and release information in the app data file.

Since the app itself does not include any content, I did not add content tags. In that regard, I would argue that it is comparable to a web browser or PDF viewer.