### PR TITLE
Migrate from dbus-glib to GDBus with gdbus-codegen

### DIFF
--- a/.ci-build.yml
+++ b/.ci-build.yml
@@ -3,7 +3,6 @@ requires:
     - appstream-glib
     - biblesync
     - cmake
-    - dbus-glib
     - docbook-utils
     - enchant
     - git
@@ -56,7 +55,6 @@ requires:
     - intltool
     - itstool
     - libbiblesync-dev
-    - libdbus-glib-1-dev
     - libglade2-dev
     - libenchant-2-dev
     - libgail-3-dev
@@ -79,7 +77,6 @@ requires:
   fedora:
     - biblesync-devel
     - cmake
-    - dbus-glib-devel
     - desktop-file-utils
     - git
     - docbook-utils
@@ -112,7 +109,6 @@ requires:
     - intltool
     - itstool
     - libbiblesync-dev
-    - libdbus-glib-1-dev
     - libenchant-2-dev
     - libgail-3-dev
     - libglade2-dev

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -51,7 +51,6 @@ jobs:
             biblesync \
             binutils \
             cmake \
-            dbus-glib \
             docbook-utils \
             enchant \
             gcc \
@@ -92,7 +91,6 @@ jobs:
             biblesync \
             binutils \
             cmake \
-            dbus-glib \
             docbook-utils \
             enchant \
             gcc \
@@ -130,7 +128,6 @@ jobs:
           dnf install -y \
             biblesync-devel \
             cmake \
-            dbus-glib-devel \
             desktop-file-utils \
             git \
             docbook-utils \
@@ -179,7 +176,6 @@ jobs:
             intltool \
             itstool \
             libbiblesync-dev \
-            libdbus-glib-1-dev \
             libenchant-2-dev \
             libgail-3-dev \
             libgtk-3-dev \
@@ -223,7 +219,6 @@ jobs:
             intltool \
             itstool \
             libbiblesync-dev \
-            libdbus-glib-1-dev \
             libenchant-2-dev \
             libgail-3-dev \
             libgtk-3-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,7 +67,6 @@ dependencies installed:
     WebKit1 or Webkit2     Port to Gtk+ of the WebKit rendering engine
     appstream-util         Utility to validate AppStream metadata
     biblesync>=1.2.0       Protocol to support Bible software shared co-navigation
-    dbus-glib              API for use of D-Bus from GLib applications
     desktop-file-validate  Validates a desktop file
     gcc                    GCC, the GNU Compiler Collection
     gconfmm                C++ wrappers for GConf
@@ -234,7 +233,7 @@ Create a build directory as a sibling of the xiphos directory:
 
 ## 3. Install dependencies
 
-    $ sudo dnf install cmake gcc-c++ intltool make gtk3-devel dbus-glib-devel gtkhtml3-devel webkitgtk4-devel libidn-devel libxml2-devel libgsf-devel minizip-devel sword-devel libuuid-devel biblesync-devel intltool libappstream-glib-devel desktop-file-utils itstool yelp yelp-tools
+    $ sudo dnf install cmake gcc-c++ intltool make gtk3-devel gtkhtml3-devel webkitgtk4-devel libidn-devel libxml2-devel libgsf-devel minizip-devel sword-devel libuuid-devel biblesync-devel intltool libappstream-glib-devel desktop-file-utils itstool yelp yelp-tools
 
 ## 4. Configure build
 
@@ -256,7 +255,7 @@ Build Xiphos On *Debian*, *Ubuntu*, or *Linux Mint*:
 
 ## 2. Install the required dependencies:
 
-    $ sudo apt-get install appstream-util cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libbiblesync-dev libdbus-glib-1-dev libenchant-2-dev libgail-3-dev libglade2-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.1-dev libxml2-dev libxml2-utils make python3-dev swig uuid-dev uuid-runtime yelp-tools xzip
+    $ sudo apt-get install appstream-util cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libbiblesync-dev libenchant-2-dev libgail-3-dev libglade2-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.1-dev libxml2-dev libxml2-utils make python3-dev swig uuid-dev uuid-runtime yelp-tools xzip
 
 ## 3. Build and install:
 
@@ -376,11 +375,11 @@ Create a build directory as a sibling of the xiphos and biblesync directories:
 
 For Win32:
 
-    $ sudo dnf install mingw32-sword.noarch mingw32-minizip.noarch mingw32-libgsf.noarch mingw32-libglade2.noarch mingw32-webkitgtk.noarch mingw32-gtk3.noarch mingw32-libtiff.noarch mingw32-libidn.noarch mingw32-gdb.noarch mingw32-nsis mingw32-dbus-glib
+    $ sudo dnf install mingw32-sword.noarch mingw32-minizip.noarch mingw32-libgsf.noarch mingw32-libglade2.noarch mingw32-webkitgtk.noarch mingw32-gtk3.noarch mingw32-libtiff.noarch mingw32-libidn.noarch mingw32-gdb.noarch mingw32-nsis
 
 For Win64:
 
-    $ sudo dnf install mingw64-sword.noarch mingw64-minizip.noarch mingw64-libgsf.noarch mingw64-libglade2.noarch mingw64-webkitgtk.noarch mingw64-gtk3.noarch mingw64-libtiff.noarch mingw64-libidn.noarch mingw64-gdb.noarch mingw32-nsis mingw64-dbus-glib
+    $ sudo dnf install mingw64-sword.noarch mingw64-minizip.noarch mingw64-libgsf.noarch mingw64-libglade2.noarch mingw64-webkitgtk.noarch mingw64-gtk3.noarch mingw64-libtiff.noarch mingw64-libidn.noarch mingw64-gdb.noarch mingw32-nsis
 
 ### 8. Build and install Biblesync with Mingw
 Cross-compiling Biblesync using MinGW. Check the instructions in the INSTALL.md

--- a/cmake/XiphosBuildTools.cmake
+++ b/cmake/XiphosBuildTools.cmake
@@ -36,11 +36,6 @@ xiphos_find_program (GLIB_GENMARSHAL glib-genmarshal)
 xiphos_find_program (XMLLINT xmllint)
 xiphos_find_program (XSLTPROC xsltproc)
 
-# dbus tools
-if (DBUS)
-  xiphos_find_program (DBUS_BINDING_TOOL dbus-binding-tool)
-endif (DBUS)
-
 # i18n tools
 if (I18N)
   # we need itstool for translating Help

--- a/cmake/XiphosDependencies.cmake
+++ b/cmake/XiphosDependencies.cmake
@@ -163,13 +163,6 @@ else (GTK2)
 endif (GTK2)
 
 
-# D-Bus dependencies
-IF (DBUS)
-  pkg_check_modules(DBus REQUIRED IMPORTED_TARGET
-    "dbus-glib-1"
-    )
-ENDIF()
-
 # find threads
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/cpack/fedora/XiphosRPMPkg.cmake
+++ b/cpack/fedora/XiphosRPMPkg.cmake
@@ -68,7 +68,7 @@ This build produced by Xiphos development; not from official Fedora repo.")
 
 # RPM spec requires field
 set(CPACK_RPM_PACKAGE_REQUIRES
-  "sword, biblesync, dbus-glib, libglade2, gtk3, webkitgtk4, gtkhtml3, yelp")
+  "sword, biblesync, libglade2, gtk3, webkitgtk4, gtkhtml3, yelp")
 
 # RPM spec obsoletes field.
 set(CPACK_RPM_PACKAGE_OBSOLETES "xiphos-gtk2, xiphos-gtk3, xiphos-common")

--- a/cpack/fedora/xiphos.spec.in
+++ b/cpack/fedora/xiphos.spec.in
@@ -10,7 +10,6 @@ Vendor:         @CPACK_PACKAGE_VENDOR@
 
 BuildRequires:  biblesync-devel >= 2.0.1-3
 BuildRequires:  desktop-file-utils
-BuildRequires:  dbus-glib-devel
 BuildRequires:  GConf2-devel
 BuildRequires:  gettext
 BuildRequires:  desktop-file-utils

--- a/doc/Translating-Xiphos.md
+++ b/doc/Translating-Xiphos.md
@@ -468,7 +468,6 @@ On Debian/Ubuntu, install the Build-Essential package:
 You need to install the following dependencies:
 
     biblesync			Protocol to support Bible software shared co-navigation
-    dbus-glib		    API for use of D-Bus from GLib applications
     gconfmm		        C++ wrappers for GConf
     gtk+-3.0            The GIMP Toolkit
     gtkhtml	            Lightweight HTML rendering/editing engine
@@ -480,13 +479,13 @@ You need to install the following dependencies:
 
 On RHEL/CentOS/Fedora, run:
 
-    dnf install intltool gtk3-devel dbus-glib-devel gtkhtml3-devel
+    dnf install intltool gtk3-devel gtkhtml3-devel
 	webkitgtk4-devel libxml2-devel libgsf-devel gconfmm26-devel sword-devel
 	libuuid-devel biblesync-devel
 
 On Debian/Ubuntu:
 
-    apt install intltool libdbus-glib-1-dev libwebkitgtk-3.0-dev
+    apt install intltool libwebkitgtk-3.0-dev
 	libxml2-dev libgsf-1-dev libgconfmm-2.6-dev libsword-dev uuid-dev
     libwebkitgtk-dev libglade2-dev
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -22,31 +22,36 @@
 if (HAVE_DBUS)
   message (STATUS "Configuring xiphos-nav target")
 
-  # we first need to generate ipc-interface.h
-  add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ipc-interface.h
-    # process ipc-interface.xml to generate ipc-interface.h
-    COMMAND ${DBUS_BINDING_TOOL}
-    --mode=glib-client
-    --output=${CMAKE_CURRENT_BINARY_DIR}/ipc-interface.h
-    --prefix=ipc_object ${CMAKE_CURRENT_SOURCE_DIR}/../gtk/ipc-interface.xml
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Generating src/example/ipc-interface.h"
+  # Generate client-side D-Bus bindings using gdbus-codegen
+  add_custom_command (
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ipc-gdbus.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ipc-gdbus.c
+
+    COMMAND gdbus-codegen
+    --interface-prefix org.xiphos.
+    --generate-c-code ipc-gdbus
+    --c-namespace Xiphos
+    ${CMAKE_CURRENT_SOURCE_DIR}/../gtk/ipc-interface.xml
+    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/../gtk/ipc-interface.xml
+
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating D-Bus client bindings for examples"
     )
 
   add_executable (
     xiphos-nav
     xiphos-nav.c
-    ${CMAKE_CURRENT_BINARY_DIR}/ipc-interface.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ipc-gdbus.c
     )
 
 
   # specify include directories to use when compiling
   target_include_directories (xiphos-nav
     PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR} # for ipc-interface.h
+    ${CMAKE_CURRENT_BINARY_DIR}
     Threads::Threads
     PkgConfig::Core
-    PkgConfig::DBus
+    PkgConfig::Gnome
     )
 
   # specify libraries or flags to use when linking
@@ -54,7 +59,7 @@ if (HAVE_DBUS)
     PRIVATE
     Threads::Threads
     PkgConfig::Core
-    PkgConfig::DBus
+    PkgConfig::Gnome
     )
 
 

--- a/src/examples/Makefile
+++ b/src/examples/Makefile
@@ -1,6 +1,4 @@
-interface_xml := ../gtk/ipc-interface.xml
-
-pkg_packages := dbus-1 dbus-glib-1
+pkg_packages := glib-2.0 gio-2.0
 
 PKG_CFLAGS := $(shell pkg-config --cflags $(pkg_packages))
 PKG_LDFLAGS := $(shell pkg-config --libs $(pkg_packages))
@@ -10,8 +8,6 @@ ADD_CFLAGS := -g -Wall -DG_DISABLE_DEPRECATED
 CFLAGS := $(PKG_CFLAGS) $(ADD_CFLAGS) $(CFLAGS)
 LDFLAGS := $(PKG_LDFLAGS) $(LDFLAGS)
 
-cleanfiles := ipc-client-stub.h
-
 targets = client
 
 .PHONY: all clean
@@ -20,12 +16,8 @@ all: $(targets)
 client: receive.o
 	$(CC) $^ -o $@ $(LDFLAGS)
 
-receive.o: ipc_client.c ipc-client-stub.h
+receive.o: ipc_client.c
 	   $(CC) $(CFLAGS) -DPROGRNAME=\"ipc_client\" -c $< -o $@
 
-ipc-client-stub.h: $(interface_xml)
-		   dbus-binding-tool --prefix=ipc_object --mode=glib-client \
-		   $< > $@
-
 clean:
-	$(RM) $(targets) $(cleanfiles) *.o
+	$(RM) $(targets) *.o

--- a/src/gtk/CMakeLists.txt
+++ b/src/gtk/CMakeLists.txt
@@ -138,11 +138,13 @@ add_executable (xiphos
   )
 
 if (DBUS)
-  # need to generate 3 files: marshal.c marshal.h ipc-interface.h
+  # need to generate 4 files using gdbus-codegen:
+  # marshal.c, marshal.h, ipc-gdbus.c, ipc-gdbus.h
   add_custom_command (
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/marshal.h
     ${CMAKE_CURRENT_BINARY_DIR}/marshal.c
-    ${CMAKE_CURRENT_BINARY_DIR}/ipc-interface.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ipc-gdbus.h
+    ${CMAKE_CURRENT_BINARY_DIR}/ipc-gdbus.c
 
     # process marshal.list to generate marshal.h
     COMMAND ${GLIB_GENMARSHAL}
@@ -151,22 +153,23 @@ if (DBUS)
     --header > ${CMAKE_CURRENT_BINARY_DIR}/marshal.h
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/marshal.list
 
-    # process marshal.list to generate marschal.c
+    # process marshal.list to generate marshal.c
     COMMAND ${GLIB_GENMARSHAL}
     ${CMAKE_CURRENT_SOURCE_DIR}/marshal.list
     --prefix=ipc_marshal
     --body > ${CMAKE_CURRENT_BINARY_DIR}/marshal.c
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/marshal.list
 
-    # process ipc-interface.xml to generate ipc-interface.h
-    COMMAND ${DBUS_BINDING_TOOL}
-    --mode=glib-server
-    --output=${CMAKE_CURRENT_BINARY_DIR}/ipc-interface.h
-    --prefix=ipc_object ${CMAKE_CURRENT_SOURCE_DIR}/ipc-interface.xml
+    # process ipc-interface.xml with gdbus-codegen to generate GDBus bindings
+    COMMAND gdbus-codegen
+    --interface-prefix org.xiphos.
+    --generate-c-code ipc-gdbus
+    --c-namespace Xiphos
+    ${CMAKE_CURRENT_SOURCE_DIR}/ipc-interface.xml
     MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/ipc-interface.xml
 
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Generating src/gtk files"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "Generating src/gtk D-Bus bindings"
     )
 
   # add files to the sources
@@ -174,14 +177,10 @@ if (DBUS)
     PRIVATE
     ipc.c
     ${CMAKE_CURRENT_BINARY_DIR}/marshal.c
+    ${CMAKE_CURRENT_BINARY_DIR}/ipc-gdbus.c
     )
   target_include_directories (xiphos
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-    PkgConfig::DBus
-    )
-  target_link_libraries(xiphos
-    PRIVATE
-    PkgConfig::DBus
     )
 endif (DBUS)
 

--- a/src/gui/ipc.h
+++ b/src/gui/ipc.h
@@ -23,7 +23,7 @@
 #define __XIPHOS_IPC_H__
 
 #include <glib.h>
-#include <dbus/dbus-glib.h>
+#include <gio/gio.h>
 
 G_BEGIN_DECLS
 #define IPC_TYPE_OBJECT (ipc_object_get_type())

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -80,11 +80,6 @@ target_link_libraries(main
 IF (DBUS)
   target_include_directories (main
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-    PkgConfig::DBus
-    )
-  target_link_libraries(main
-    PRIVATE
-    PkgConfig::DBus
     )
 ENDIF (DBUS)
 

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -146,8 +146,6 @@ if (WIN32)
   install(FILES
     ${SYS_ROOT_BIN}/libsword-1-9-0.dll
     ${SYS_ROOT_BIN}/libminizip-1.dll
-    ${SYS_ROOT_BIN}/libdbus-1-3.dll
-    ${SYS_ROOT_BIN}/libdbus-glib-1-2.dll
     ${SYS_ROOT_BIN}/addld.exe
     ${SYS_ROOT_BIN}/emptyvss.exe
     ${SYS_ROOT_BIN}/imp2gbs.exe

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -5,8 +5,8 @@ VOLUME /source
 # Installs dependencies once and for all
 RUN dnf -y update --refresh && \
     dnf -y install autoconf automake cmake git fpc gettext glib2-devel itstool libxslt make subversion yelp-tools zip && \
-    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-dbus-glib mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk mingw32-xz && \
-    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-dbus-glib mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk mingw64-xz && \
+    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk mingw32-xz && \
+    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk mingw64-xz && \
     dnf clean all
 
 ADD build_sword.sh /build_sword.sh


### PR DESCRIPTION
Replace the deprecated dbus-glib library with GDBus and use gdbus-codegen to generate D-Bus bindings from ipc-interface.xml:

- Use gdbus-codegen to generate XiphosRemote skeleton/proxy from XML
- Server: Use XiphosRemoteSkeleton with signal-based method handlers
- Clients: Use type-safe XiphosRemoteProxy for method calls/signals
- Remove dbus-binding-tool dependency from build system
- Remove dbus-glib from all build and packaging dependencies

GDBus is already available through GLib. D-Bus interface remains compatible.

Fixes: #1049