### PR TITLE
Fix GTK critical error causing freeze when changing Bible books

### DIFF
--- a/src/gtk/parallel_tab.c
+++ b/src/gtk/parallel_tab.c
@@ -227,8 +227,8 @@ GtkWidget *_create_parallel_tab(void)
 	g_signal_connect(G_OBJECT(parallel_vbox), "destroy",
 			 G_CALLBACK(on_parallel_tab_destroy), NULL);
 	gtk_widget_show(parallel_vbox);
-	gtk_box_pack_start(GTK_BOX(widgets.page), parallel_vbox, TRUE,
-			   TRUE, 0);
+	/* Don't pack into widgets.page here - let the caller manage placement
+	 * to avoid "widget already has a parent" GTK errors when switching tabs */
 	toolbar29 = create_nav_toolbar();
 	gtk_widget_show(toolbar29);
 	gtk_box_pack_start(GTK_BOX(parallel_vbox), toolbar29, FALSE, FALSE,

--- a/src/gtk/tabbed_browser.c
+++ b/src/gtk/tabbed_browser.c
@@ -1467,8 +1467,8 @@ void gui_open_parallel_view_in_new_tab(void)
 	notebook_main_add_page(pt);
 	pt->paratab = gui_create_parallel_tab();
 	gui_parallel_tab_sync((gchar *)settings.currentverse);
-	/*gtk_box_pack_start(GTK_BOX(widgets.page), pt->paratab, TRUE, TRUE,
-	   0); */
+	gtk_box_pack_start(GTK_BOX(widgets.page), pt->paratab, TRUE, TRUE,
+			   0);
 	gtk_notebook_set_current_page(GTK_NOTEBOOK(widgets.notebook_main),
 				      gtk_notebook_page_num(GTK_NOTEBOOK(widgets.notebook_main),
 							    pt->page_widget));


### PR DESCRIPTION
Fixed a critical bug where Xiphos would freeze when attempting to change Bible books, throwing the GTK error:
"gtk_box_pack: assertion '_gtk_widget_get_parent (child) == NULL' failed"

Root cause: The parallel_vbox widget was being packed into widgets.page twice - once during creation in _create_parallel_tab() and again by the caller in tabbed_browser.c during session restore. GTK does not allow a widget to be added to a container when it already has a parent.

Remove the automatic packing of parallel_vbox into widgets.page from _create_parallel_tab(). The function now only creates and returns the widget, following GTK best practices of separating widget creation from placement.

Uncomment a gtk_box_pack_start() call to ensure the parallel tab widget is properly packed when opening a parallel view in a new tab.

The widget is now packed exactly once by the caller, preventing the "widget already has a parent" error and eliminating the freeze.

Probably fixes: #1088