### PR TITLE
Fix #1091: show commentary introductions in chapter display

### DIFF
--- a/src/main/display.cc
+++ b/src/main/display.cc
@@ -127,6 +127,7 @@ h3 { font-style: %s } --> \
 using namespace sword;
 using namespace std;
 
+
 //
 // user annotation cache filling.
 //
@@ -859,6 +860,16 @@ GTKEntryDisp::displayByChapter(SWModule &imodule, int columns)
 			else
 				rework = g_string_new(cVerse.GetText());
 		}
+
+		if (!cVerse.HeaderIsValid())
+			CacheHeader(cVerse, imodule, ops, backend);
+		if (cache_flags & ModuleCache::Headings) {
+			swbuf.append(settings.imageresize
+					 ? AnalyzeForImageSize(cVerse.GetHeader(), CURRENT_COLUMNS,
+							       GDK_WINDOW(gtk_widget_get_window(gtkText)))
+					 : cVerse.GetHeader() /* left as-is */);
+		} else
+			cVerse.InvalidateHeader();
 
 		// add an anchor for where in the chapter we are.
 		// (commentaries can have big sections on 1 verse [<hr>],

--- a/src/webkit/wk-html.c
+++ b/src/webkit/wk-html.c
@@ -67,15 +67,7 @@ static gboolean button_release_handler(GtkWidget *widget, GdkEventButton *event)
 	if (event->type == GDK_BUTTON_RELEASE && db_click) {
 		XI_message((" button 1 = %s", "double click!\n"));
 
-#ifdef USE_WEBKIT2
-		webkit_web_view_execute_editing_command(WEBKIT_WEB_VIEW(widget),
-							WEBKIT_EDITING_COMMAND_COPY);
-#else
-		if (webkit_web_view_has_selection(WEBKIT_WEB_VIEW(widget))) {
-			webkit_web_view_copy_clipboard(WEBKIT_WEB_VIEW(widget));
-		}
-#endif
-		GtkClipboard *clipboard = gtk_widget_get_clipboard(widget, GDK_SELECTION_CLIPBOARD);
+		GtkClipboard *clipboard = gtk_widget_get_clipboard(widget, GDK_SELECTION_PRIMARY);
 		gtk_clipboard_request_text(clipboard, gui_get_clipboard_text_for_lookup, NULL);
 	}
 


### PR DESCRIPTION
Commentary modules like MHC store introduction text as entry
attributes (Heading/Preverse) like Bible modules do, but
GTKEntryDisp::displayByChapter() never called CacheHeader()
to retrieve and display them.

Add CacheHeader() call in the verse loop of displayByChapter()
to match the existing behavior in GTKChapDisp::display().