### PR TITLE
Fix parallel tab crash, navigation problem and blank windows

### DIFF
--- a/src/gtk/preferences_dialog.c
+++ b/src/gtk/preferences_dialog.c
@@ -3113,6 +3113,8 @@ void ps_button_cut(GtkButton *button, gpointer user_data)
 		}
 		xml_set_value("Xiphos", "modules", "parallels", mod_list);
 		g_free(mod_list);
+		if (settings.parallel_list && settings.parallel_list[0])
+			gui_navbar_parallel_set_module(settings.parallel_list[0]);
 	}
 	g_free(str);
 }


### PR DESCRIPTION
## Problems fixed

**1. Blank parallel tab after navigation**
In `on_entry_activate()`, `main_update_parallel_page()` was called when in tab mode (`showparatab`), but this function writes to `widgets.html_parallel` which is the detached window widget. The parallel tab actually uses `widgets.html_parallel_dialog`. This caused a blank white panel in the parallel tab.

Fix: replace the `if/else` block with a direct call to `main_update_parallel_page_detached()` which correctly uses `widgets.html_parallel_dialog` in both tab and detached modes.

**2. Navigation blocked after removing a module from parallel list**
In `ps_button_remove()`, after rebuilding `settings.parallel_list`, `gui_navbar_parallel_set_module()` was never called. The navbar kept the old module's v11n, blocking navigation when the new first module has a different versification.

Fix: call `gui_navbar_parallel_set_module(settings.parallel_list[0])` after the list is rebuilt.

## Known remaining issue

The last visited verse in the parallel tab does not seem to be memorized/restored correctly across sessions. We have not investigated this yet — is this a pre-existing issue or something introduced by recent changes? Is it a blocker for you?

## Testing

Tested on Linux — parallel tab displays correctly, navigation works after module removal.