### PR TITLE
dict history: fix navigation buttons signal connections

### DIFF
--- a/src/gtk/dictlex.c
+++ b/src/gtk/dictlex.c
@@ -50,7 +50,8 @@
 
 #include "gui/debug_glib_null.h"
 #include <time.h>
-
+void button_dict_back_clicked(GtkButton *button, gpointer user_data);
+void button_dict_forward_clicked(GtkButton *button, gpointer user_data);
 /******************************************************************************
  * externs
  */
@@ -486,6 +487,10 @@ GtkWidget *gui_create_dictionary_pane(void)
 	g_signal_connect(G_OBJECT(widgets.entry_dict), "activate",
 			 G_CALLBACK(dict_key_entry_changed), NULL);
 
+	g_signal_connect((gpointer)widgets.button_dict_back, "clicked",
+			G_CALLBACK(button_dict_back_clicked), NULL);
+	g_signal_connect((gpointer)widgets.button_dict_forward, "clicked",
+			G_CALLBACK(button_dict_forward_clicked), NULL);
 	g_signal_connect((gpointer)button10, "clicked",
 			 G_CALLBACK(button_back_clicked), NULL);
 	g_signal_connect((gpointer)button11, "clicked",

--- a/src/main/sword.cc
+++ b/src/main/sword.cc
@@ -911,7 +911,6 @@ void main_dictionary_entry_changed(char *mod_name)
 	backend->display_mod->display();
 
 	gtk_entry_set_text(GTK_ENTRY(widgets.entry_dict), key);
-	main_dict_history_add(mod_name, key);
 	g_free(key);
 }
 
@@ -1250,6 +1249,7 @@ void main_display_dictionary(const char *mod_name,
 		gtk_entry_set_text(GTK_ENTRY(widgets.entry_dict), key);
 		gtk_widget_activate(widgets.entry_dict);
 	}
+	main_dict_history_add(mod_name, key);
 
 	//if (settings.browsing)
 	gui_update_tab_struct(NULL,
@@ -2043,8 +2043,14 @@ void main_devotional_button_clicked(gint direction)
 
 void main_dict_history_add(const gchar *mod_name, const gchar *key)
 {
-    if (dict_history_navigating) return;  /* ne pas enregistrer pendant navigation */
-
+	if (dict_history_navigating) return;  /* do not record during navigation */
+	/* do not add if identical to last entry */
+	if (dict_history_back) {
+		DictHistoryEntry *last = (DictHistoryEntry *)g_list_last(dict_history_back)->data;
+		if (!strcmp(last->key, key) && !strcmp(last->mod_name, mod_name))
+			return;
+	}
+    
     /* vider le forward quand on consulte une nouvelle entrée */
     g_list_free_full(dict_history_forward, dict_history_entry_free);
     dict_history_forward = NULL;


### PR DESCRIPTION
The dictionary pane had back/forward history navigation buttons that
were not working. This patch fixes two issues:

1. In gui_create_dictionary_pane() (dictlex.c), the "clicked" signals
   for the history buttons were connected to the wrong widgets (button10
   and button11, which are the alphabetic navigation buttons) and to the
   wrong callbacks (button_back_clicked/button_forward_clicked). They
   are now correctly connected to widgets.button_dict_back and
   widgets.button_dict_forward with their dedicated callbacks
   button_dict_back_clicked/button_dict_forward_clicked.

2. In main_display_dictionary() (sword.cc), main_dict_history_add()
   was only called from main_dictionary_entry_changed(), which is not
   reached for all navigation paths (e.g. clicking a Strong's link).
   It is now called directly in main_display_dictionary(), with a guard
   to prevent duplicate entries when the same key is consulted twice
   in a row.

Files changed:
- src/gtk/dictlex.c
- src/main/sword.cc