### PR TITLE
sidebar: add Edit button to personal commentary/Prayerlist right-click menu

### DIFF
--- a/src/gtk/sidebar.c
+++ b/src/gtk/sidebar.c
@@ -79,6 +79,7 @@ extern gboolean shift_key_pressed;
 extern gboolean initialized;
 
 static GtkWidget *create_menu_modules(void);
+static GtkWidget *create_menu_percomm_mod(void);
 void on_export_verselist_activate(GtkMenuItem *menuitem,
 				  gpointer user_data);
 
@@ -580,10 +581,22 @@ static gboolean on_modules_list_button_release(GtkWidget *widget,
 		break;
 
 	case 3:
-		if (mod && (g_utf8_collate(mod, _("Parallel View"))) && (g_utf8_collate(mod, _("Standard View"))) //) {
-		    && (main_get_mod_type(mod) != PRAYERLIST_TYPE)) {
+		if (mod && (main_get_mod_type(mod) == PERCOM_TYPE)) {
 			buf_module = mod;
-			create_menu_modules();
+			GtkWidget *percomm_menu = create_menu_percomm_mod();
+		#if GTK_CHECK_VERSION(3, 22, 0)
+			gtk_menu_popup_at_pointer(GTK_MENU(percomm_menu), (GdkEvent *)event);
+	#else
+		gtk_menu_popup(GTK_MENU(percomm_menu), NULL, NULL, NULL, NULL, 0, gtk_get_current_event_time());
+	#endif
+		g_free(caption);
+		return FALSE;
+	}
+
+		if (mod && (g_utf8_collate(mod, _("Parallel View"))) && (g_utf8_collate(mod, _("Standard View"))) //) {
+    && (main_get_mod_type(mod) != PRAYERLIST_TYPE)) {
+		buf_module = mod;
+		create_menu_modules();
 			/*gtk_menu_popup(GTK_MENU(sidebar.menu_modules),
 			   NULL, NULL, NULL, NULL,
 			   0, gtk_get_current_event_time()); */
@@ -1150,7 +1163,50 @@ GtkWidget *create_menu_prayerlist(void)
 
 void on_edit_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	editor_create_new(buf_module, NULL, BOOK_EDITOR);
+		editor_create_new(buf_module, "0", BOOK_EDITOR);
+}
+
+G_MODULE_EXPORT void
+on_edit_percomm_activate(GtkMenuItem *menuitem, gpointer user_data)
+{
+	editor_create_new(buf_module,
+			  (gchar *)settings.currentverse,
+			  NOTE_EDITOR);
+	g_free(buf_module);
+	buf_module = NULL;
+}
+
+static GtkWidget *
+create_menu_percomm_mod(void)
+{
+	GtkWidget *menu;
+	gchar *glade_file;
+#ifdef USE_GTKBUILDER
+	GtkBuilder *gxml;
+	glade_file = gui_general_user_file("xi-menus-popup.gtkbuilder", FALSE);
+#else
+	GladeXML *gxml;
+	glade_file = gui_general_user_file("xi-menus.glade", FALSE);
+#endif
+	g_return_val_if_fail((glade_file != NULL), NULL);
+
+#ifdef USE_GTKBUILDER
+	gxml = gtk_builder_new();
+	gtk_builder_add_from_file(gxml, glade_file, NULL);
+#else
+	gxml = glade_xml_new(glade_file, "menu_percomm_mod", NULL);
+#endif
+	g_free(glade_file);
+	g_return_val_if_fail((gxml != NULL), NULL);
+
+	menu = UI_GET_ITEM(gxml, "menu_percomm_mod");
+#ifdef USE_GTKBUILDER
+	gtk_builder_connect_signals(gxml, NULL);
+#else
+	glade_xml_signal_autoconnect_full(gxml,
+		(GladeXMLConnectFunc)gui_glade_signal_connect_func, NULL);
+#endif
+	return menu;
 }
 
 GtkWidget *create_menu_prayerlist_mod(void)

--- a/ui/xi-menus-popup.gtkbuilder
+++ b/ui/xi-menus-popup.gtkbuilder
@@ -244,6 +244,52 @@
       </object>
     </child>
   </object>
+  <object class="GtkMenu" id="menu_percomm_mod">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkImageMenuItem" id="open_in_new_tab_percomm">
+        <property name="label" translatable="yes">Open in new tab</property>
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+        <signal name="activate" handler="on_open_in_tab_activate2" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="open_in_a_dialog_percomm">
+        <property name="label" translatable="yes">Open in a separate window</property>
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+        <signal name="activate" handler="on_open_in_dialog_activate" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="edit_percomm">
+        <property name="label" translatable="yes">Edit</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Open this personal commentary in the editor</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_edit_percomm_activate" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="about_percomm">
+        <property name="label" translatable="yes">About</property>
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+        <signal name="activate" handler="on_about2_activate" swapped="no"/>
+      </object>
+    </child>
+  </object>
   <object class="GtkMenu" id="menu_popup">
     <property name="can_focus">False</property>
     <child>
@@ -904,6 +950,16 @@
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
         <signal name="activate" handler="on_open_in_dialog_activate" swapped="no"/>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="edit_prayerlist">
+        <property name="label" translatable="yes">Edit</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="tooltip_text" translatable="yes">Open this prayer list in the editor</property>
+        <property name="use_underline">True</property>
+        <signal name="activate" handler="on_edit_activate" swapped="no"/>
       </object>
     </child>
     <child>

--- a/ui/xi-menus.glade
+++ b/ui/xi-menus.glade
@@ -2082,7 +2082,15 @@
       </child>
     </widget>
   </child>
-
+  <child>
+	<widget class="GtkMenuItem" id="edit_prayerlist">
+      <property name="visible">True</property>
+      <property name="tooltip" translatable="yes">Open this prayer list in the editor</property>
+      <property name="label" translatable="yes">Edit</property>
+      <property name="use_underline">True</property>
+      <signal name="activate" handler="on_edit_activate" last_modification_time="Tue, 07 Apr 2009 23:37:07 GMT"/>
+    </widget>
+  </child>
   <child>
     <widget class="GtkImageMenuItem" id="about">
       <property name="visible">True</property>
@@ -2102,6 +2110,79 @@
       </child>
     </widget>
   </child>
+</widget>
+
+<widget class="GtkMenu" id="menu_percomm_mod">
+
+  <child>
+    <widget class="GtkImageMenuItem" id="open_in_new_tab_percomm">
+      <property name="visible">True</property>
+      <property name="tooltip" translatable="yes">Open selected module in a new tab</property>
+      <property name="label" translatable="yes">Open in new tab</property>
+      <property name="use_underline">True</property>
+      <signal name="activate" handler="on_open_in_tab_activate2" last_modification_time="Tue, 07 Apr 2009 23:29:59 GMT"/>
+      <child internal-child="image">
+	<widget class="GtkImage" id="image_percomm_tab">
+	  <property name="visible">True</property>
+	  <property name="pixbuf">new_tab_button.png</property>
+	  <property name="xalign">0.5</property>
+	  <property name="yalign">0.5</property>
+	  <property name="xpad">0</property>
+	  <property name="ypad">0</property>
+	</widget>
+      </child>
+    </widget>
+  </child>
+
+  <child>
+    <widget class="GtkImageMenuItem" id="open_in_a_dialog_percomm">
+      <property name="visible">True</property>
+      <property name="tooltip" translatable="yes">Open selected module in a separate window</property>
+      <property name="label" translatable="yes">Open in a separate window</property>
+      <property name="use_underline">True</property>
+      <signal name="activate" handler="on_open_in_dialog_activate" last_modification_time="Tue, 07 Apr 2009 23:37:07 GMT"/>
+      <child internal-child="image">
+	<widget class="GtkImage" id="image_percomm_dialog">
+	  <property name="visible">True</property>
+	  <property name="pixbuf">dlg-un-16.png</property>
+	  <property name="xalign">0.5</property>
+	  <property name="yalign">0.5</property>
+	  <property name="xpad">0</property>
+	  <property name="ypad">0</property>
+	</widget>
+      </child>
+    </widget>
+  </child>
+
+  <child>
+    <widget class="GtkMenuItem" id="edit_percomm">
+      <property name="visible">True</property>
+      <property name="tooltip" translatable="yes">Open this personal commentary in the editor</property>
+      <property name="label" translatable="yes">Edit</property>
+      <property name="use_underline">True</property>
+      <signal name="activate" handler="on_edit_percomm_activate" last_modification_time="Tue, 07 Apr 2009 23:37:07 GMT"/>
+    </widget>
+  </child>
+
+  <child>
+    <widget class="GtkImageMenuItem" id="about_percomm">
+      <property name="visible">True</property>
+      <property name="label" translatable="yes">About</property>
+      <property name="use_underline">True</property>
+      <signal name="activate" handler="on_about2_activate" last_modification_time="Fri, 06 Mar 2009 14:37:21 GMT"/>
+      <child internal-child="image">
+	<widget class="GtkImage" id="image_percomm_about">
+	  <property name="visible">True</property>
+	  <property name="pixbuf">sword_icon-16.png</property>
+	  <property name="xalign">0.5</property>
+	  <property name="yalign">0.5</property>
+	  <property name="xpad">0</property>
+	  <property name="ypad">0</property>
+	</widget>
+      </child>
+    </widget>
+  </child>
+
 </widget>
 
 <widget class="GtkMenu" id="menu_edit_tree">


### PR DESCRIPTION
**Description :**
```
Previously, editing a personal commentary or a prayer list module required
right-clicking inside the commentary/book pane itself. This adds an "Edit"
option directly to the right-click context menu of the sidebar module list,
consistent with how other actions (open in tab, open in window) are already
exposed there.

Changes:
- xi-menus-popup.gtkbuilder: add "Edit" item to menu_prayerlist_mod; add new
  menu_percomm_mod with Open in tab, Open in window, Edit and About items
- sidebar.c: fix on_edit_activate to pass "0" as key for BOOK_EDITOR; add
  on_edit_percomm_activate handler and create_menu_percomm_mod(); intercept
  PERCOM_TYPE in the case 3 button handler to show the dedicated percomm menu