### PR TITLE
Fix #839: attach prayerlist submenu to File menu item after sidebar init

### DIFF
--- a/src/gtk/xiphos.c
+++ b/src/gtk/xiphos.c
@@ -98,7 +98,9 @@ void frontend_init(void)
 	 *  setup sidebar
 	 */
 	gui_create_sidebar(widgets.epaned);
-
+	/* attach prayerlist submenu to File menu item, now that sidebar is ready */
+	gtk_menu_item_set_submenu(GTK_MENU_ITEM(widgets.new_journal_item),
+				  sidebar.menu_prayerlist);
 	/*
 	 *  parallel stuff
 	 */


### PR DESCRIPTION
Previously, gui_menu_prayerlist_popup() used gtk_menu_popup_at_widget() with the File menu item as anchor, causing the File menu to disappear.

Instead, attach sidebar.menu_prayerlist directly as a submenu of the new_journal_item after sidebar initialization, which is the correct GTK pattern for nested menus.
Solves #839