### PR TITLE
display: implement DisplayLevel for genbooks (fix issue #528)

### DIFF
--- a/src/main/display.cc
+++ b/src/main/display.cc
@@ -24,6 +24,7 @@
 #endif
 
 #include <glib.h>
+#include <treekeyidx.h>
 
 #include <osisxhtml.h>
 #include <thmlxhtml.h>
@@ -954,6 +955,42 @@ GTKEntryDisp::displayByChapter(SWModule &imodule, int columns)
 //
 // general display of entries: commentary, genbook, lexdict
 //
+static void
+_render_display_level(SWModule &imodule, unsigned long offset,
+                      int max_level, int cur_level, SWBuf &combined)
+{
+	TreeKeyIdx *treekey = (TreeKeyIdx *)imodule.getKey();
+	treekey->setOffset(offset);
+	imodule.getRawEntry(); // snap to entry
+
+	const char *raw = imodule.getRawEntry();
+	if (raw && *raw) {
+		if (combined.length() > 0)
+			combined += "<br/><hr/>";
+		combined += imodule.renderText().c_str();
+	}
+
+	if (cur_level < max_level && treekey->hasChildren()) {
+		treekey->firstChild();
+		unsigned long child_offset = treekey->getOffset();
+		bool has_next = true;
+		while (has_next) {
+			_render_display_level(imodule, child_offset,
+					      max_level, cur_level + 1,
+					      combined);
+			// reposition after recursion
+			treekey->setOffset(child_offset);
+			imodule.getRawEntry();
+			has_next = treekey->nextSibling() && !treekey->popError();
+			if (has_next)
+				child_offset = treekey->getOffset();
+		}
+		// restore to current node
+		treekey->setOffset(offset);
+		imodule.getRawEntry();
+	}
+}
+
 char
 GTKEntryDisp::display(SWModule &imodule)
 {
@@ -1075,28 +1112,31 @@ GTKEntryDisp::display(SWModule &imodule)
 		    (modtype == PRAYERLIST_TYPE))
 			rework = g_string_new(strongs_or_morph
 						  ? block_render(imodule.getRawEntry())
-						  : imodule.getRawEntry());
+: imodule.getRawEntry());
 		else {
-			rework = g_string_new(strongs_or_morph
-						  ? block_render(imodule.renderText().c_str())
-						  : imodule.renderText().c_str());
-			if (modtype == DICTIONARY_TYPE) {
-				char *f = (char *)imodule.getConfigEntry("Feature");
-				if (f && !strcmp(f, "DailyDevotion")) {
-					char *pretty;
-					char *month = backend->get_module_key();
-					char *day = strchr(month, '.');
-					if (day)
-						*(day++) = '\0';
-					else
-						day = (char *)"XX";
-					int idx_month = atoi(month) - 1;
-					pretty = gettext(month_names[idx_month]);
-					pretty = g_strdup_printf("<b>%s %s</b><br/>",
-								 (pretty ? pretty : "--"),
-								 day);
-					swbuf.append(pretty);
-					g_free(pretty);
+			// respect DisplayLevel for genbooks (BOOK_TYPE):
+			const char *dl_str = imodule.getConfigEntry("DisplayLevel");
+			int display_level = dl_str ? atoi(dl_str) : 1;
+			if (display_level <= 1) {
+				rework = g_string_new(strongs_or_morph
+							  ? block_render(imodule.renderText().c_str())
+							  : imodule.renderText().c_str());
+			} else {
+				SWMgr *mgr = backend->get_mgr();
+				SWModule *mod = mgr->Modules[imodule.getName()];
+				TreeKeyIdx *treekey = dynamic_cast<TreeKeyIdx *>(mod->getKey());
+				if (!treekey) {
+					rework = g_string_new(imodule.renderText().c_str());
+				} else {
+					TreeKeyIdx saved = *treekey;
+					SWBuf combined = "";
+					_render_display_level(*mod, saved.getOffset(),
+							      display_level, 1, combined);
+					treekey->setOffset(saved.getOffset());
+					mod->getRawEntry();
+					rework = g_string_new(strongs_or_morph
+								  ? block_render(combined.c_str())
+								  : combined.c_str());
 				}
 			}
 		}

--- a/src/main/display.cc
+++ b/src/main/display.cc
@@ -726,7 +726,7 @@ CacheHeader(ModuleCache::CacheVerse &cVerse,
 	    GLOBAL_OPS *ops, BackEnd *be)
 {
 	int x = 0;
-	gchar heading[8];
+	gchar heading[32];
 	const gchar *preverse;
 	SWBuf preverse2;
 	GString *text = g_string_new("");


### PR DESCRIPTION
Xiphos was always behaving as if DisplayLevel=1 for genbooks, regardless
of the value set in the module configuration. This meant that clicking on
a node in the tree would only display the content of that single node,
with no way to aggregate child content into a single scrollable view.

This fix reads the DisplayLevel config entry from the module and, when
it is greater than 1, recursively renders the current node and its
descendants up to the specified depth, concatenating their content with
a horizontal rule separator between each node.

Changes:
- display.cc: add #include <treekeyidx.h>
- display.cc: add static helper _render_display_level() which traverses
  the TreeKeyIdx tree by offset, rendering each node's content into a
  SWBuf, up to max_level depth
- display.cc: in GTKEntryDisp::display(), read DisplayLevel from module
  config and call _render_display_level() when value > 1, falling back
  to the original single-node rendering when DisplayLevel is absent or 1

Module maintainers who want to benefit from this feature need to add
DisplayLevel=N to their module's .conf file, where N reflects the depth
of the tree they want rendered on a single click.

Fixes #528