### PR TITLE
Fix/fedora43 install deps

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -233,7 +233,10 @@ Create a build directory as a sibling of the xiphos directory:
 
 ## 3. Install dependencies
 
-    $ sudo dnf install cmake gcc-c++ intltool make gtk3-devel gtkhtml3-devel webkitgtk4-devel libidn-devel libxml2-devel libgsf-devel minizip-devel sword-devel libuuid-devel biblesync-devel intltool libappstream-glib-devel desktop-file-utils itstool yelp yelp-tools
+    $ sudo dnf install cmake gcc-c++ intltool make gtk3-devel webkit2gtk4.1-devel libidn-devel libxml2-devel libgsf-devel minizip-devel sword-devel libuuid-devel biblesync-devel libappstream-glib-devel desktop-file-utils itstool yelp yelp-tools libsoup3-devel
+> **Note:** `gtkhtml3-devel` was retired in Fedora 41+.
+> The **notes editor** feature will not be available unless `gtkhtml3-devel` is installed.
+
 
 ## 4. Configure build
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -240,7 +240,7 @@ Create a build directory as a sibling of the xiphos directory:
 
 ## 4. Configure build
 
-    $ cmake -DCMAKE_INSTALL_PREFIX=/usr -DGTKHTML=ON ../xiphos
+    $ cmake -DCMAKE_INSTALL_PREFIX=/usr ../xiphos
 
 ## 5. Build and install, run xiphos
 


### PR DESCRIPTION
Tested on Fedora 43 in a clean toolbox container. 

Updates the Fedora dependency list to reflect changes in Fedora 41+:
- `webkitgtk4-devel` renamed to `webkit2gtk4.1-devel`
- `libsoup3-devel` added as a new explicit dependency introduced with the webkit2gtk4.1 migration
- `gtkhtml3-devel` removed from the install command and noted as retired in Fedora 41+, with a note that the notes editor feature requires it
- Removed duplicate `intltool` entry

Removed `-DGTKHTML=ON` from the example build configuration command as it causes a cmake error on Fedora 41+ since gtkhtml is no longer available