### PR TITLE
Addressing review feedback: Fix CMake comments and downgrade FATAL to WARNING

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -173,6 +173,7 @@ List of options:
 Option   | Functionality                                  | Default
 -------- | ---------------------------------------------- | -------
 GTK2     | Force UI build with Gtk2 instead of Gtk3.      | OFF
+GTKTVEDITOR | Force GTK TextView editor, overriding `GTKHTML` and `WEBKIT1`. | OFF
 GTKHTML  | Force gtkhtml editor instead of webkit editor. | OFF
 WEBKIT1  | Force webkit1 instead of webkit2.              | OFF
 DBUS     | Use the Xiphos dbus API.                       | ON

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -234,13 +234,12 @@ Create a build directory as a sibling of the xiphos directory:
 ## 3. Install dependencies
 
     $ sudo dnf install cmake gcc-c++ intltool make gtk3-devel webkit2gtk4.1-devel libidn-devel libxml2-devel libgsf-devel minizip-devel sword-devel libuuid-devel biblesync-devel libappstream-glib-devel desktop-file-utils itstool yelp yelp-tools libsoup3-devel
-> **Note:** `gtkhtml3-devel` was retired in Fedora 41+.
-> The **notes editor** feature will not be available unless `gtkhtml3-devel` is installed.
+> **Note:** `gtkhtml3-devel` was retired in Fedora 41+ and must be installed manually to enable the cmake flag `-DGTKHTML`.
 
 
 ## 4. Configure build
 
-    $ cmake -DCMAKE_INSTALL_PREFIX=/usr ../xiphos
+    $ cmake -DCMAKE_INSTALL_PREFIX=/usr -DGTKTVEDITOR=ON ../xiphos
 
 ## 5. Build and install, run xiphos
 

--- a/cmake/XiphosDependencies.cmake
+++ b/cmake/XiphosDependencies.cmake
@@ -121,7 +121,7 @@ if (GTK2)
     )
 else (GTK2)
   if (WEBKIT1 AND GTKHTML)
-    # Gtk+-3.0 + Webkit1 + WebKit-editor
+    # Gtk+-3.0 + Webkit1 + GtkHtml-editor
     pkg_check_modules(Gtk REQUIRED IMPORTED_TARGET
       "gtk+-3.0"
       "webkitgtk-3.0"
@@ -130,14 +130,14 @@ else (GTK2)
       )
   endif()
   if (WEBKIT1 AND NOT GTKHTML)
-    # Gtk+-3.0 + Webkit1 + GtkHtml-editor
+    # Gtk+-3.0 + Webkit1 + Webkit-editor
     pkg_check_modules(Gtk REQUIRED IMPORTED_TARGET
       "gtk+-3.0"
       "webkitgtk-3.0"
       )
   endif()
   if (NOT WEBKIT1 AND GTKHTML)
-    # Gtk+-3.0 + Webkit2 + WebKit-editor
+    # Gtk+-3.0 + Webkit2 + GtkHtml-editor
     pkg_check_modules(Gtk REQUIRED IMPORTED_TARGET
       "gtk+-3.0"
       "gtkhtml-editor-4.0"
@@ -149,11 +149,14 @@ else (GTK2)
     endif()
   endif()
   if (NOT WEBKIT1 AND NOT GTKHTML)
-    # This configuration does not build, as the Webkit-editor
-    # code makes use of webkit1 APIs, not webkit2, and thus fails
-    # looking for its headers
-    message(FATAL "Webkit Editor is not supported with webkit2")
-    # Gtk+-3.0 + Webkit2 + GtkHtml-editor
+    # Gtk+-3.0 + WebKit2, no GtkHtml-editor or Webkit-editor features enabled
+
+    # Note: Without WEBKIT1, GTKHTML, or GTKTVEDITOR, Xiphos builds as a
+    # pure WebKit2 app — functional, but without the notes/journal editor.
+    if (NOT WEBKIT1 AND NOT GTKHTML AND NOT GTKTVEDITOR)
+        message(WARNING "No editor flag set (WEBKIT1, GTKHTML, GTKTVEDITOR) — notes/journal editor will be unavailable")
+    endif()
+    
     pkg_check_modules(Gtk REQUIRED IMPORTED_TARGET "gtk+-3.0")
     pkg_check_modules(WK IMPORTED_TARGET "webkit2gtk-4.1")
     if(NOT WK_FOUND)


### PR DESCRIPTION
The CMake dependencies in XiphosDependencies.cmake contained a few inaccuracies:

- A few comments indicating WebKit1 vs GtkHTML editor support were swapped
- The NOT WEBKIT1 AND NOT GTKHTML configuration used message(FATAL ...) which does not actually stop the build, and the comment incorrectly stated this configuration does not build.

As of testing on Fedora 43, with the flags -DGTKHTML=OFF, -DWEBKIT1=OFF, and -DGTKTVEDITOR=OFF the configuration builds successfully, but without editor support. Downgraded to message(WARNING ...) and updated the comments to accurately reflect the updated behavior with recent GTK TextView editor support.

Additionally, updated INSTALL.md to better reflect gtkhtml editor support and awareness of the GTKTVEDITOR functionality. Also updated the Fedora build instructions to default to -DGTKTVEDITOR=ON, since its dependencies are already covered by the dnf install command — unlike -DGTKHTML=ON which was previously used but required manual package installation.