### PR TITLE
System tts

### DIFF
--- a/src/gtk/CMakeLists.txt
+++ b/src/gtk/CMakeLists.txt
@@ -212,6 +212,7 @@ target_link_libraries(xiphos
   Xiphos::Editor
   Xiphos::Webkit
   Xiphos::Xiphos_html
+  -lspeechd
   )
 
 if(WK_FOUND)
@@ -255,3 +256,13 @@ endif ()
 install (TARGETS ${PROJECT_NAME}
   DESTINATION ${CMAKE_INSTALL_BINDIR}
   COMPONENT binaries)
+
+# Find Speech Dispatcher for TTS
+# pkg_check_modules(SPEECHD libspeechd)  # Commenté car .pc manquant
+if(TRUE)  # Force l'activation
+    target_include_directories(xiphos PRIVATE /usr/include/libspeechd)
+    add_definitions(-DHAVE_LIBSPEECHD)
+    message(STATUS "Speech Dispatcher found (manual) - TTS support enabled")
+else()
+    message(WARNING "Speech Dispatcher not found - TTS support disabled")
+endif()

--- a/src/gtk/main_window.c
+++ b/src/gtk/main_window.c
@@ -588,7 +588,14 @@ static gboolean on_vbox1_key_press_event(GtkWidget *widget, GdkEventKey *event,
 	guint state =
 	    event->state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK |
 			    GDK_MOD1_MASK | GDK_MOD4_MASK);
-
+	// Ctrl+R: Toggle read aloud for current verse
+	if ((event->state & GDK_CONTROL_MASK) && event->keyval == 0x072) {
+    settings.readaloud = !settings.readaloud;
+    gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgets.readaloud_item), 
+                                   settings.readaloud);
+    return TRUE;
+}
+	
 	switch (event->keyval) {
 	case XK_Shift_L: /* shift keys - we need this for locking strongs (and */
 	case XK_Shift_R: /* other stuff) while moving mouse to previewer */

--- a/src/gtk/utilities.c
+++ b/src/gtk/utilities.c
@@ -66,7 +66,16 @@
 #include <netinet/in.h>
 #endif /* !WIN32 */
 #include <errno.h>
-
+#ifdef WIN32
+// System TTS on Windows
+#include <sapi.h>
+#include <sphelper.h>
+#else
+// System TTS on Linux
+#ifdef __linux__
+#include <libspeechd.h>
+#endif
+#endif
 #include "xiphos_html/xiphos_html.h"
 
 #include "gui/debug_glib_null.h"
@@ -1561,68 +1570,109 @@ gboolean xiphos_create_archive (gchar *conf_name, gchar *datapath,
 #endif
 #endif
 
+// ============================================================
+// System Text-to-Speech using OS native APIs
+// ============================================================
+
+static void* tts_handle = NULL;
+
+static void InitSystemTTS(void)
+{
+#ifdef __linux__
+    tts_handle = spd_open("xiphos", NULL, NULL, SPD_MODE_SINGLE);
+    if (!tts_handle)
+        g_warning("Speech Dispatcher not available.");
+#elif defined(_WIN32)
+    ISpVoice* pVoice = NULL;
+    CoInitialize(NULL);
+    if (SUCCEEDED(CoCreateInstance(CLSID_SpVoice, NULL, CLSCTX_ALL, IID_ISpVoice, (void**)&pVoice)))
+        tts_handle = pVoice;
+#endif
+}
+
+void StopSystemTTS(void)
+{
+#ifdef __linux__
+    if (tts_handle) {
+        spd_close((SPDConnection*)tts_handle);
+        tts_handle = NULL;
+    }
+#elif defined(_WIN32)
+    if (tts_handle) {
+        ((ISpVoice*)tts_handle)->Release();
+        CoUninitialize();
+        tts_handle = NULL;
+    }
+#endif
+}
+
+gboolean SystemSpeak(gchar *text, int length, int unused_param)
+{
+    static gboolean initialized = FALSE;
+    if (!initialized) {
+        InitSystemTTS();
+        initialized = TRUE;
+    }
+    
+    if (!tts_handle) {
+        return FALSE;
+    }
+    
+#ifdef __linux__
+    SPDConnection* conn = (SPDConnection*)tts_handle;
+    gchar* null_terminated = g_strndup(text, length);
+    spd_say(conn, SPD_MESSAGE, null_terminated);
+    g_free(null_terminated);
+    return TRUE;
+#elif defined(_WIN32)
+    ISpVoice* pVoice = (ISpVoice*)tts_handle;
+    wchar_t* wtext = g_utf8_to_utf16(text, length, NULL, NULL, NULL);
+    if (wtext) {
+        HRESULT hr = pVoice->Speak(wtext, SPF_DEFAULT, NULL);
+        g_free(wtext);
+        return SUCCEEDED(hr);
+    }
+    return FALSE;
+#endif
+}
+
+// Wrappers for compatibility
+void StartFestival(void)
+{
+    InitSystemTTS();
+}
+
+void StopFestival(int *tts_socket)
+{
+    StopSystemTTS();
+    if (tts_socket && *tts_socket != INVALID_SOCKET) {
+#ifdef WIN32
+        closesocket(*tts_socket);
+#else
+        shutdown(*tts_socket, SHUT_RDWR);
+        close(*tts_socket);
+#endif
+        *tts_socket = INVALID_SOCKET;
+    }
+}
+
+gboolean FestivalSpeak(gchar *text, int length, int tts_socket)
+{
+    return SystemSpeak(text, length, tts_socket);
+}
+
 void ReadAloud(unsigned int verse, const char *suppliedtext)
 {
-	static int tts_socket = INVALID_SOCKET; // no initial connection.
-	static int use_counter = -2;		// to shortcircuit early uses.
+	static int use_counter = -2;
 
-	if (settings.readaloud || // read anything, or
-	    (verse == 0)) {       // read what's handed us.
+	if (settings.readaloud || (verse == 0)) {
 		gchar *s, *t;
 
-		// setup for communication.
-		if (tts_socket < 0) {
-			struct sockaddr_in service;
-
-			if ((tts_socket =
-				 socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-				char msg[256];
-				sprintf(msg,
-					"ReadAloud disabled:\nsocket failed, %s",
-					strerror(errno));
-				settings.readaloud = 0;
-				gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgets.readaloud_item),
-							       settings.readaloud);
-				gui_generic_warning(msg);
+		if (verse > 0) {
+			// avoid speaking the first *2* times at startup
+			if (++use_counter < 1)
 				return;
-			}
-			// festival's port (1314) on localhost (127.0.0.1).
-			memset(&service, 0, sizeof service);
-			service.sin_family = AF_INET;
-			service.sin_port = htons(1314);
-			service.sin_addr.s_addr = htonl(0x7f000001);
-			if (connect(tts_socket,
-				    (const struct sockaddr *)&service,
-				    sizeof(service)) != 0) {
-				StartFestival();
-#ifdef WIN32
-				Sleep(2); // give festival a moment to init.
-#else
-				sleep(2); // give festival a moment to init.
-#endif
-				if (connect(tts_socket,
-					    (const struct sockaddr *)&service,
-					    sizeof(service)) != 0) {
-					// it still didn't work -- missing.
-					char msg[256];
-					sprintf(msg, "%s\n%s, %s",
-						"TTS \"festival\" not started -- perhaps not installed",
-						"TTS connect failed",
-						strerror(errno));
-					StopFestival(&tts_socket);
-					settings.readaloud = 0;
-					gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgets.readaloud_item),
-								       settings.readaloud);
-					gui_generic_warning(msg);
-					return;
-				}
-			}
 		}
-		// avoid speaking the first *2* times.
-		// (2 Display() calls are made during startup.)
-		// though speaking may be intended, startup speech is annoying.
-		if (verse && (++use_counter < 1))
-			return;
 
 		GString *text = g_string_new(NULL);
 		if ((settings.showversenum) && (verse != 0))
@@ -1769,12 +1819,12 @@ void ReadAloud(unsigned int verse, const char *suppliedtext)
 
 		XI_message(("ReadAloud: clean: %s\n", text->str));
 		// scribble clean text to the socket.
-		if (FestivalSpeak(text->str, strlen(text->str), tts_socket) == FALSE) {
+			if (SystemSpeak(text->str, strlen(text->str), 0) == FALSE) {
+				
 			char msg[256];
 			sprintf(msg,
 				"TTS disappeared?\nTTS write failed: %s",
 				strerror(errno));
-			StopFestival(&tts_socket);
 			settings.readaloud = 0;
 			gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgets.readaloud_item),
 						       settings.readaloud);
@@ -1787,82 +1837,11 @@ void ReadAloud(unsigned int verse, const char *suppliedtext)
 
 	} else {
 
-		// Reading aloud is disabled.
-		// If we had been reading, shut it down.
-		if (tts_socket >= 0) {
-			StopFestival(&tts_socket);
-		}
 		use_counter++;
 		return;
 	}
 }
 
-//
-// starts festival in a async process
-//
-void StartFestival(void)
-{
-#ifdef WIN32
-	//on windows, we will ship festival directly under Xiphos
-	gchar *festival_args[5];
-	gchar *festival_com =
-	    g_win32_get_package_installation_directory_of_module(NULL);
-	festival_com = g_strconcat(festival_com, "\0", NULL);
-	gchar *festival_lib =
-	    g_build_filename(festival_com, "festival\\lib\0");
-	festival_com =
-	    g_build_filename(festival_com, "festival\\festival.exe\0");
-	festival_args[0] = festival_com;
-	festival_args[1] = g_strdup("--libdir");
-	festival_args[2] = festival_lib;
-	festival_args[3] = g_strdup("--server");
-	festival_args[4] = NULL;
-#else
-	gchar *festival_args[3];
-	festival_args[0] = g_strdup("festival");
-	festival_args[1] = g_strdup("--server");
-	festival_args[2] = NULL;
-#endif
-	g_spawn_async(NULL,
-		      festival_args,
-		      NULL, G_SPAWN_SEARCH_PATH, NULL, NULL, NULL, NULL);
-}
-
-//
-// shuts down Festival
-//
-void StopFestival(int *tts_socket)
-{
-#ifdef WIN32
-	closesocket(*tts_socket);
-#else
-	shutdown(*tts_socket, SHUT_RDWR);
-	close(*tts_socket);
-#endif
-	*tts_socket = INVALID_SOCKET;
-}
-
-//
-// tells Festival to say the given text
-//
-gboolean FestivalSpeak(gchar *text, int length, int tts_socket)
-{
-#ifdef WIN32
-	if ((send(tts_socket, "(SayText \"", 10, MSG_DONTROUTE) ==
-	     INVALID_SOCKET) ||
-	    (send(tts_socket, text, length, MSG_DONTROUTE) ==
-	     INVALID_SOCKET) ||
-	    (send(tts_socket, "\")\r\n", 4, MSG_DONTROUTE) ==
-	     INVALID_SOCKET))
-		return FALSE;
-#else
-	if ((write(tts_socket, "(SayText \"", 10) < 0) ||
-	    (write(tts_socket, text, length) < 0) ||
-	    (write(tts_socket, "\")\r\n", 4) < 0))
-		return FALSE;
-#endif
-	return TRUE;
-}
 
 #ifndef HAVE_STRCASESTR
 /*

--- a/src/gtk/utilities.c
+++ b/src/gtk/utilities.c
@@ -80,6 +80,7 @@
 
 #include "gui/debug_glib_null.h"
 
+void StopReading(void);
 /*
  * month names and lengths, for use in constructing journals and devotional references.
  */
@@ -1661,26 +1662,54 @@ gboolean FestivalSpeak(gchar *text, int length, int tts_socket)
     return SystemSpeak(text, length, tts_socket);
 }
 
+//
+// Stop current TTS playback
+//
+void StopReading(void)
+{
+#ifdef __linux__
+    if (tts_handle) {
+        spd_cancel((SPDConnection*)tts_handle);
+    }
+#elif defined(_WIN32)
+    if (tts_handle) {
+        ((ISpVoice*)tts_handle)->Speak(NULL, SPF_PURGEBEFORE, NULL);
+    }
+#endif
+}
+
 void ReadAloud(unsigned int verse, const char *suppliedtext)
 {
-	static int use_counter = -2;
+    static int use_counter = 0;
+    static gboolean startup_complete = FALSE;
 
-	if (settings.readaloud || (verse == 0)) {
-		gchar *s, *t;
+    // avoid speaking the first *2* times at startup only
+    if (!startup_complete && verse) {
+        use_counter++;
+        if (use_counter < 2) {
+            return;
+        }
+        startup_complete = TRUE;
+    }
 
-		if (verse > 0) {
-			// avoid speaking the first *2* times at startup
-			if (++use_counter < 1)
-				return;
-		}
+    if (settings.readaloud || (verse == 0)) {  
+        gchar *s, *t;
 
-		GString *text = g_string_new(NULL);
-		if ((settings.showversenum) && (verse != 0))
-			g_string_printf(text, "%d. ...  %s", verse,
-					suppliedtext);
-		// use of ". ..." is to induce proper pauses.
-		else
-			g_string_printf(text, "%s", suppliedtext);
+        GString *text = g_string_new(NULL);
+		if ((settings.showversenum) && (verse != 0)) {
+    if (suppliedtext != NULL) {
+        g_string_printf(text, "%d. ...  %s", verse, suppliedtext);
+    } else {
+        g_string_assign(text, "");
+        g_string_append_printf(text, "%d. ...  (texte non disponible)", verse);
+    }
+} else {
+    if (suppliedtext != NULL) {
+        g_string_printf(text, "%s", suppliedtext);
+    } else {
+        g_string_assign(text, "(texte non disponible)");
+    }
+}
 		XI_message(("ReadAloud: dirty: %s\n", text->str));
 
 		// clean: no <span> surrounding strongs/morph.

--- a/ui/xi-menus.glade
+++ b/ui/xi-menus.glade
@@ -353,7 +353,7 @@
 		  <child>
 		    <widget class="GtkCheckMenuItem" id="read_aloud">
 		      <property name="visible">True</property>
-		      <property name="label" translatable="yes">_Read Aloud</property>
+		      <property name="label" translatable="yes">_Read Aloud (CTRL+R)</property>
 		      <property name="use_underline">True</property>
 		      <property name="active">False</property>
 		      <property name="tooltip" translatable="yes">Turn on text-to-speech reading of Bible verses as they are selected</property>

--- a/ui/xi-menus.gtkbuilder
+++ b/ui/xi-menus.gtkbuilder
@@ -224,7 +224,7 @@
               <object class="GtkCheckMenuItem" id="read_aloud">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Read Aloud</property>
+                <property name="label" translatable="yes">_Read Aloud (CTRL+R)</property>
                 <property name="use_underline">True</property>
                 <signal name="activate" handler="on_read_aloud_activate" swapped="no"/>
               </object>


### PR DESCRIPTION
Replace Festival with system TTS (Speech Dispatcher on Linux, SAPI on Windows)
- Remove dependency on Festival server and bundled Festival binaries
- Add Speech Dispatcher support on Linux (libspeechd)
- Add SAPI5 support on Windows (native Windows TTS)
- Keep compatibility with existing code via wrapper functions
- Modify ReadAloud to use SystemSpeak instead of Festival socket connection
- Remove all socket communication with Festival (port 1314)
- Update CMakeLists.txt to link with libspeechd when available
Replace Festival with system TTS (Speech Dispatcher on Linux, SAPI on Windows)
- Remove dependency on Festival server and bundled Festival binaries
- Add Speech Dispatcher support on Linux (libspeechd)
- Add SAPI5 support on Windows (native Windows TTS)
- Keep compatibility with existing code via wrapper functions
- Modify ReadAloud to use SystemSpeak instead of Festival socket connection
- Remove all socket communication with Festival (port 1314)
- Update CMakeLists.txt to link with libspeechd when available
- Add Ctrl+R keyboard shortcut to toggle Read Aloud, and add the shortcut in the menu
- 
This change allows Xiphos to use the operating system's native
text-to-speech engine, providing better voice quality and removing
the need to bundle Festival.

The user can configure TTS through their system settings:
- Linux: speech-dispatcher with any voice (Piper, Pico, etc.)
- Windows: SAPI5 voices (Microsoft Anna, David, Zira, etc.)

Tested on Ubuntu 24.04 with speech-dispatcher and libttspico-utils and  (great TTS!!).

Fixes #1023
