### PR TITLE
Fix daily devotional preview, Restore the ability to manually enter a date in the Devotional tab on Windows

### DIFF
--- a/src/gtk/dictlex.c
+++ b/src/gtk/dictlex.c
@@ -619,30 +619,38 @@ GtkWidget *gui_create_devotional_pane(void)
 	gtk_widget_show(hbox);
 	gtk_box_pack_start(GTK_BOX(box_devot), hbox, FALSE, FALSE, 0);
 
-	widgets.entry_devotional = gtk_entry_new();
+widgets.entry_devotional = gtk_entry_new();
 	gtk_entry_set_max_length(GTK_ENTRY(widgets.entry_devotional), 5);
-
+#ifdef _WIN32
+	/* Windows: GtkCalendar is broken — show the MM.DD text entry instead */
+	gtk_entry_set_width_chars(GTK_ENTRY(widgets.entry_devotional), 6);
+	gtk_widget_set_tooltip_text(widgets.entry_devotional, _("Date MM.DD"));
+	gtk_widget_show(widgets.entry_devotional);
+	gtk_box_pack_start(GTK_BOX(hbox), widgets.entry_devotional, FALSE, FALSE, 0);
+	widgets.button_devotional_date = NULL;
+	widgets.popover_devotional     = NULL;
+	widgets.calendar_devotional    = NULL;
+#else
 	widgets.button_devotional_date = gtk_button_new_with_label("--");
 	gtk_widget_show(widgets.button_devotional_date);
 	gtk_widget_set_tooltip_text(widgets.button_devotional_date,
 								_("Click to choose a date"));
 	gtk_box_pack_start(GTK_BOX(hbox), widgets.button_devotional_date,
 					   FALSE, FALSE, 0);
-
 	/* GtkPopover stick to the button */
 #if GTK_CHECK_VERSION(3, 12, 0)
 	widgets.popover_devotional = gtk_popover_new(widgets.button_devotional_date);
 	gtk_popover_set_position(GTK_POPOVER(widgets.popover_devotional),
                              GTK_POS_BOTTOM);
 #endif
-
 	/* GtkCalendar in the popover */
 	widgets.calendar_devotional = gtk_calendar_new();
 	gtk_widget_show(widgets.calendar_devotional);
-	#if GTK_CHECK_VERSION(3, 12, 0)
-    gtk_container_add(GTK_CONTAINER(widgets.popover_devotional),
+#if GTK_CHECK_VERSION(3, 12, 0)
+	gtk_container_add(GTK_CONTAINER(widgets.popover_devotional),
                       widgets.calendar_devotional);
 #endif
+#endif /* _WIN32 */
 
 	/* prev button */
 	button_prev = gtk_button_new();
@@ -690,10 +698,12 @@ GtkWidget *gui_create_devotional_pane(void)
 #endif
 
 	/* signaux */
+#ifndef _WIN32
 	g_signal_connect(G_OBJECT(widgets.button_devotional_date), "clicked",
 					 G_CALLBACK(on_button_devotional_date_clicked), NULL);
 	g_signal_connect(G_OBJECT(widgets.calendar_devotional), "day-selected-double-click",
 					 G_CALLBACK(on_calendar_day_selected), NULL);
+#endif 
 	g_signal_connect(G_OBJECT(widgets.entry_devotional), "activate",
 					 G_CALLBACK(devot_key_entry_changed), NULL);
 	g_signal_connect((gpointer)button_prev, "clicked",

--- a/src/gtk/main_menu.c
+++ b/src/gtk/main_menu.c
@@ -347,8 +347,14 @@ on_about_translation_activate(GtkMenuItem *menuitem, gpointer user_data)
 G_MODULE_EXPORT void
 on_daily_devotion_activate(GtkMenuItem *menuitem, gpointer user_data)
 {
-	gtk_notebook_set_current_page(GTK_NOTEBOOK(widgets.notebook_dict_devot), 1);
-    main_display_devotional(widgets.html_devotional);
+	settings.showdevotional =
+	    gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(menuitem));
+	xml_set_value("Xiphos", "misc", "dailydevotional",
+	              settings.showdevotional ? "1" : "0");
+	if (settings.showdevotional) {
+		gtk_notebook_set_current_page(GTK_NOTEBOOK(widgets.notebook_dict_devot), 1);
+		main_display_devotional(widgets.html_devotional);
+	}
 }
 
 /******************************************************************************
@@ -1002,6 +1008,7 @@ GtkWidget *gui_create_main_menu(void)
 	    UI_GET_ITEM(gxml, "show_parallel_view_in_a_tab");
 	widgets.side_preview_item =
 	    UI_GET_ITEM(gxml, "show_previewer_in_sidebar");
+	widgets.daily_devotion_item = UI_GET_ITEM(gxml, "daily_devotion");
 	widgets.new_journal_item = UI_GET_ITEM(gxml, "newjournal");
 
 	/* map tab's show state into view menu. */
@@ -1017,7 +1024,9 @@ GtkWidget *gui_create_main_menu(void)
 				       settings.showparatab);
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgets.side_preview_item),
 				       settings.show_previewer_in_sidebar);
-
+	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgets.daily_devotion_item),
+				       settings.showdevotional);
+				       
 	/* update other status toys */
 	gtk_check_menu_item_set_active(GTK_CHECK_MENU_ITEM(widgets.linkedtabs_item),
 				       settings.linkedtabs);

--- a/src/gui/widgets.h
+++ b/src/gui/widgets.h
@@ -93,7 +93,7 @@ struct _app_widgets
 	    /* popup menu submenu widgets */
 	    *add_bookmark_submenu,
 	    /* popup menu item widgets */
-	    *viewtexts_item, *viewpreview_item, *parallel_tab_item, *side_preview_item, *viewcomms_item, *viewdicts_item, *linkedtabs_item, *showversenum_item, *readaloud_item, *versehighlight_item, *annotate_highlight_item, *xrefs_in_verse_list_item, *new_journal_item, *button_dict_book, *button_new_tab, /* creates a new passage tab */
+	    *viewtexts_item, *viewpreview_item, *parallel_tab_item, *side_preview_item, *viewcomms_item, *viewdicts_item, *linkedtabs_item, *showversenum_item, *readaloud_item, *versehighlight_item, *annotate_highlight_item, *xrefs_in_verse_list_item, *new_journal_item, *daily_devotion_item, *button_dict_book, *button_new_tab, /* creates a new passage tab */
 	    *button_dict_back, *button_dict_forward,  /* ← Create history nav button */
 	    *hboxtb;																																				   /* container for browsing notebook and button */
 };

--- a/ui/xi-menus.glade
+++ b/ui/xi-menus.glade
@@ -278,7 +278,7 @@
 		<widget class="GtkMenu" id="menuitem6_menu">
 
 		  <child>
-		    <widget class="GtkMenuItem" id="daily_devotion">
+		    <widget class="GtkCheckMenuItem" id="daily_devotion">
 		      <property name="visible">True</property>
 		      <property name="label" translatable="yes">Preview _Daily Devotion</property>
 		      <property name="use_underline">True</property>

--- a/ui/xi-menus.gtkbuilder
+++ b/ui/xi-menus.gtkbuilder
@@ -155,7 +155,7 @@
           <object class="GtkMenu" id="menuitem6_menu">
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkMenuItem" id="daily_devotion">
+              <object class="GtkCheckMenuItem" id="daily_devotion">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Preview _Daily Devotion</property>


### PR DESCRIPTION
  * Restore checkable 'Preview Daily Devotion' menu item; save and restore state across sessions.
  * Restore the ability to manually enter a date in the Devotional tab on Windows without losing the calendar on Linux.
Solves #1300 