### PR TITLE
fix #1309 update appstream-util -> appstreamcli.

### DIFF
--- a/.ci-build.yml
+++ b/.ci-build.yml
@@ -1,6 +1,6 @@
 requires:
   archlinux:
-    - appstream-glib
+    - appstream
     - biblesync
     - cmake
     - docbook-utils
@@ -44,7 +44,7 @@ requires:
     - which
 
   debian:
-    - appstream-util
+    - appstream
     - cmake
     - docbook-utils
     - g++
@@ -75,6 +75,7 @@ requires:
     - zip
 
   fedora:
+    - appstream
     - biblesync-devel
     - cmake
     - desktop-file-utils
@@ -85,7 +86,6 @@ requires:
     - gtkhtml3-devel
     - intltool
     - itstool
-    - libappstream-glib-devel
     - libsoup3-devel
     - libuuid-devel
     - libxml2-devel
@@ -99,7 +99,7 @@ requires:
     - zip
 
   ubuntu:
-    - appstream-util
+    - appstream
     - cmake
     - g++
     - desktop-file-utils

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           pacman -Syu --noconfirm
           pacman -S --noconfirm \
-            appstream-glib \
+            appstream \
             biblesync \
             binutils \
             cmake \
@@ -87,6 +87,7 @@ jobs:
       - name: install dependencies
         run: |
           dnf install -y \
+            appstream \
             biblesync-devel \
             cmake \
             desktop-file-utils \
@@ -96,7 +97,6 @@ jobs:
             gtk3-devel \
             intltool \
             itstool \
-            libappstream-glib-devel \
             libsoup3-devel \
             libuuid-devel \
             libxml2-devel \
@@ -128,7 +128,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y \
-            appstream-util \
+            appstream \
             cmake \
             docbook-utils \
             g++ \
@@ -173,7 +173,7 @@ jobs:
         run: |
           apt-get update
           apt-get install -y \
-            appstream-util \
+            appstream \
             cmake \
             g++ \
             desktop-file-utils \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ dependencies installed:
     CMake                  Cross-platform make system
     Gtk+-2.0 or GTK+-3.0   The GIMP Toolkit
     WebKit1 or Webkit2     Port to Gtk+ of the WebKit rendering engine
-    appstream-util         Utility to validate AppStream metadata
+    appstreamcli           Utility to validate AppStream metadata
     biblesync>=1.2.0       Protocol to support Bible software shared co-navigation
     desktop-file-validate  Validates a desktop file
     gcc                    GCC, the GNU Compiler Collection
@@ -234,7 +234,7 @@ Create a build directory as a sibling of the xiphos directory:
 
 ## 3. Install dependencies
 
-    $ sudo dnf install cmake gcc-c++ intltool make gtk3-devel webkit2gtk4.1-devel libidn-devel libxml2-devel libgsf-devel minizip-devel sword-devel libuuid-devel biblesync-devel libappstream-glib-devel desktop-file-utils itstool yelp yelp-tools libsoup3-devel
+    $ sudo dnf install cmake gcc-c++ intltool make gtk3-devel webkit2gtk4.1-devel libidn-devel libxml2-devel libgsf-devel minizip-devel sword-devel libuuid-devel biblesync-devel appstream desktop-file-utils itstool yelp yelp-tools libsoup3-devel
 > **Note:** `gtkhtml3-devel` was retired in Fedora 41+ and must be installed manually to enable the cmake flag `-DGTKHTML`.
 
 
@@ -258,7 +258,7 @@ Build Xiphos On *Debian*, *Ubuntu*, or *Linux Mint*:
 
 ## 2. Install the required dependencies:
 
-    $ sudo apt-get install appstream-util cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libbiblesync-dev libenchant-2-dev libgail-3-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.1-dev libxml2-dev libxml2-utils make python3-dev swig uuid-dev uuid-runtime yelp-tools xzip
+    $ sudo apt-get install appstream cmake g++ desktop-file-utils fp-utils git gsettings-desktop-schemas-dev intltool itstool libbiblesync-dev libenchant-2-dev libgail-3-dev libgtk-3-dev libminizip-dev libsword-dev libwebkit2gtk-4.1-dev libxml2-dev libxml2-utils make python3-dev swig uuid-dev uuid-runtime yelp-tools xzip
 
 ## 3. Build and install:
 

--- a/cmake/XiphosBuildTools.cmake
+++ b/cmake/XiphosBuildTools.cmake
@@ -48,7 +48,7 @@ if (UNIX)
   # checking xiphos.desktop
   xiphos_find_program (DESKTOP_FILE_VALIDATE desktop-file-validate)
   # checking xiphos.appdata.xml
-  xiphos_find_program (APPSTREAM_UTIL appstream-util)
+  xiphos_find_program (APPSTREAMCLI appstreamcli)
 endif (UNIX)
 
 

--- a/cpack/fedora/xiphos.spec.in
+++ b/cpack/fedora/xiphos.spec.in
@@ -24,7 +24,7 @@ BuildRequires:  cmake
 BuildRequires:  gcc
 BuildRequires:  gcc-c++
 BuildRequires:  itstool
-BuildRequires:  libappstream-glib-devel
+BuildRequires:  appstream
 BuildRequires:  yelp-tools
 BuildRequires:  util-linux
 Requires:       yelp

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -90,7 +90,7 @@ if (UNIX)
   # add translations and validate xiphos.appdata.xml
   add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.appdata.xml
     COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} --xml --template "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.appdata.xml" -d "${PROJECT_SOURCE_DIR}/po" -o "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.appdata.xml"
-    COMMAND ${APPSTREAM_UTIL} validate-relax --nonet ${PROJECT_NAME}.appdata.xml > validate.timestamp
+    COMMAND ${APPSTREAMCLI} validate --no-net ${PROJECT_NAME}.appdata.xml > validate.timestamp
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "Configuring the AppData metadata file"
     )

--- a/desktop/xiphos.appdata.xml
+++ b/desktop/xiphos.appdata.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright © 2014-2025 Xiphos Development Team <xiphos-devel@crosswire.org> -->
 <component type="desktop">
- <id>xiphos.desktop</id>
+ <id>org.xiphos.Xiphos</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-2.0+</project_license>
  <name>Xiphos</name>
- <developer_name>The Xiphos Developer Team</developer_name>
  <summary>Bible Study Guide</summary>
  <launchable type="desktop-id">xiphos.desktop</launchable>
+ <developer id="org.freedesktop">
+    <name>Xiphos Development Team</name>
+ </developer>
  <description>
   <p>
     Xiphos is a program for high-grade Bible study using the modules and
@@ -32,7 +34,11 @@
     lists</li>
   </ul>
  </description>
- <screenshots>
+ <content_rating type="oars-1.1">
+   <content_attribute id="social-location">none</content_attribute>
+   <content_attribute id="social-contacts">none</content_attribute>
+ </content_rating>
+  <screenshots>
   <screenshot type="default">
    <image>https://raw.githubusercontent.com/crosswire/xiphos/master/pixmaps/screenshots/main-window.jpg</image>
    <caption>Main window</caption>

--- a/doc/Translating-Xiphos.md
+++ b/doc/Translating-Xiphos.md
@@ -492,7 +492,7 @@ On Debian/Ubuntu:
 You'll also need to install the following utilities:
 
     intltool
-    appstream-util
+    appstreamcli
     desktop-file-validate
     itstool
     xmllint


### PR DESCRIPTION
The largely useless xiphos.appstream.xml file needed attention.
Fixes #1309 and #1245 (sort of -- no release value).