### PR TITLE
adjust #1307 restore win32 read aloud: move win32 c++ funcs to sword.cc

### DIFF
--- a/src/gtk/CMakeLists.txt
+++ b/src/gtk/CMakeLists.txt
@@ -248,6 +248,10 @@ if (WIN32)
     PRIVATE
     xiphos-winres.rc
     )
+  target_link_libraries(xiphos
+    PRIVATE
+    -lsapi
+  )
 else()
   # only Linux builds link against speech lib.
   target_link_libraries(xiphos

--- a/src/gtk/utilities.c
+++ b/src/gtk/utilities.c
@@ -1618,7 +1618,7 @@ gboolean SystemSpeak(gchar *text, int length, int unused_param)
     g_free(null_terminated);
     return TRUE;
 #elif defined(_WIN32)
-    return WindowsSystemSpeak(gchar *text, int length);
+    return WindowsSystemSpeak(text, length);
 #endif
 }
 

--- a/src/gtk/utilities.c
+++ b/src/gtk/utilities.c
@@ -67,11 +67,8 @@
 #endif /* !WIN32 */
 #include <errno.h>
 #ifdef WIN32
-# if 0
 // System TTS on Windows
-#include <sapi.h>
-#include <sphelper.h>
-# endif
+// gatewayed into src/main/sword.cc.
 #else
 // System TTS on Linux
 #ifdef __linux__
@@ -1577,21 +1574,16 @@ gboolean xiphos_create_archive (gchar *conf_name, gchar *datapath,
 // System Text-to-Speech using OS native APIs
 // ============================================================
 
-static void* tts_handle = NULL;
+void* tts_handle = NULL;
 
-static void InitSystemTTS(void)
+void InitSystemTTS(void)
 {
 #ifdef __linux__
     tts_handle = spd_open("xiphos", NULL, NULL, SPD_MODE_SINGLE);
     if (!tts_handle)
         g_warning("Speech Dispatcher not available.");
 #elif defined(_WIN32)
-# if 0
-    ISpVoice* pVoice = NULL;
-    CoInitialize(NULL);
-    if (SUCCEEDED(CoCreateInstance(CLSID_SpVoice, NULL, CLSCTX_ALL, IID_ISpVoice, (void**)&pVoice)))
-        tts_handle = pVoice;
-# endif
+    WindowsInitSystemTTS();
 #endif
 }
 
@@ -1603,13 +1595,7 @@ void StopSystemTTS(void)
         tts_handle = NULL;
     }
 #elif defined(_WIN32)
-# if 0
-    if (tts_handle) {
-        ((ISpVoice*)tts_handle)->Release();
-        CoUninitialize();
-        tts_handle = NULL;
-    }
-# endif
+    WindowsStopSystemTTS();
 #endif
 }
 
@@ -1632,16 +1618,7 @@ gboolean SystemSpeak(gchar *text, int length, int unused_param)
     g_free(null_terminated);
     return TRUE;
 #elif defined(_WIN32)
-# if 0
-    ISpVoice* pVoice = (ISpVoice*)tts_handle;
-    wchar_t* wtext = g_utf8_to_utf16(text, length, NULL, NULL, NULL);
-    if (wtext) {
-        HRESULT hr = pVoice->Speak(wtext, SPF_DEFAULT, NULL);
-        g_free(wtext);
-        return SUCCEEDED(hr);
-    }
-    return FALSE;
-# endif
+    return WindowsSystemSpeak(gchar *text, int length);
 #endif
 }
 
@@ -1656,9 +1633,7 @@ void StopFestival(int *tts_socket)
     StopSystemTTS();
     if (tts_socket && *tts_socket != INVALID_SOCKET) {
 #ifdef WIN32
-# if 0
         closesocket(*tts_socket);
-# endif
 #else
         shutdown(*tts_socket, SHUT_RDWR);
         close(*tts_socket);
@@ -1682,11 +1657,7 @@ void StopReading(void)
         spd_cancel((SPDConnection*)tts_handle);
     }
 #elif defined(_WIN32)
-# if 0
-    if (tts_handle) {
-        ((ISpVoice*)tts_handle)->Speak(NULL, SPF_PURGEBEFORE, NULL);
-    }
-# endif
+    WindowsStopReading();
 #endif
 }
 

--- a/src/main/sword.cc
+++ b/src/main/sword.cc
@@ -2134,6 +2134,11 @@ void main_dict_history_forward(void)
 // System TTS on Windows
 // moved C++ functions here from src/gtk/utilities.c.
 
+#include <windows.h>
+#include <strsafe.h>
+#include <sapi.h>
+#include <sphelper.h>
+
 void WindowsInitSystemTTS(void)
 {
     ISpVoice* pVoice = NULL;

--- a/src/main/sword.cc
+++ b/src/main/sword.cc
@@ -2135,6 +2135,7 @@ void main_dict_history_forward(void)
 // moved C++ functions here from src/gtk/utilities.c.
 
 #include <windows.h>
+#include <tchar.h>
 #include <strsafe.h>
 #include <sapi.h>
 #include <sphelper.h>
@@ -2174,7 +2175,7 @@ gboolean WindowsSystemSpeak(gchar *text, int length)
 void WindowsStopReading(void)
 {
     if (tts_handle) {
-        ((ISpVoice*)tts_handle)->Speak(NULL, SPF_PURGEBEFORE, NULL);
+        ((ISpVoice*)tts_handle)->Speak(NULL, SPF_PURGEBEFORESPEAK, NULL);
     }
 }
 

--- a/src/main/sword.cc
+++ b/src/main/sword.cc
@@ -2160,7 +2160,7 @@ void WindowsStopSystemTTS(void)
 gboolean WindowsSystemSpeak(gchar *text, int length)
 {
     ISpVoice* pVoice = (ISpVoice*)tts_handle;
-    wchar_t* wtext = g_utf8_to_utf16(text, length, NULL, NULL, NULL);
+    wchar_t* wtext = reinterpret_cast<wchar_t*>g_utf8_to_utf16(text, length, NULL, NULL, NULL);
     if (wtext) {
         HRESULT hr = pVoice->Speak(wtext, SPF_DEFAULT, NULL);
         g_free(wtext);

--- a/src/main/sword.cc
+++ b/src/main/sword.cc
@@ -2126,3 +2126,51 @@ void main_dict_history_forward(void)
     gtk_widget_set_sensitive(widgets.button_dict_forward,
         dict_history_forward != NULL);
 }
+
+/* **************************************************************** */
+
+#ifdef WIN32
+
+// System TTS on Windows
+// moved C++ functions here from src/gtk/utilities.c.
+
+void WindowsInitSystemTTS(void)
+{
+    ISpVoice* pVoice = NULL;
+    CoInitialize(NULL);
+    if (SUCCEEDED(CoCreateInstance(CLSID_SpVoice, NULL, CLSCTX_ALL, IID_ISpVoice, (void**)&pVoice)))
+        tts_handle = pVoice;
+}
+
+void WindowsStopSystemTTS(void)
+{
+    if (tts_handle) {
+        ((ISpVoice*)tts_handle)->Release();
+        CoUninitialize();
+        tts_handle = NULL;
+    }
+}
+
+gboolean WindowsSystemSpeak(gchar *text, int length)
+{
+    ISpVoice* pVoice = (ISpVoice*)tts_handle;
+    wchar_t* wtext = g_utf8_to_utf16(text, length, NULL, NULL, NULL);
+    if (wtext) {
+        HRESULT hr = pVoice->Speak(wtext, SPF_DEFAULT, NULL);
+        g_free(wtext);
+        return SUCCEEDED(hr);
+    }
+    return FALSE;	// utf16 conversion failed
+}
+
+//
+// Stop current TTS playback
+//
+void WindowsStopReading(void)
+{
+    if (tts_handle) {
+        ((ISpVoice*)tts_handle)->Speak(NULL, SPF_PURGEBEFORE, NULL);
+    }
+}
+
+#endif // WIN32

--- a/src/main/sword.cc
+++ b/src/main/sword.cc
@@ -2160,7 +2160,7 @@ void WindowsStopSystemTTS(void)
 gboolean WindowsSystemSpeak(gchar *text, int length)
 {
     ISpVoice* pVoice = (ISpVoice*)tts_handle;
-    wchar_t* wtext = reinterpret_cast<wchar_t*>g_utf8_to_utf16(text, length, NULL, NULL, NULL);
+    wchar_t* wtext = reinterpret_cast<wchar_t*>(g_utf8_to_utf16(text, length, NULL, NULL, NULL));
     if (wtext) {
         HRESULT hr = pVoice->Speak(wtext, SPF_DEFAULT, NULL);
         g_free(wtext);

--- a/src/main/sword.h
+++ b/src/main/sword.h
@@ -50,6 +50,13 @@ extern "C" {
 #define DIALOG_SEARCH_PREVIEW_TYPE 11
 #define PRAYERLIST_TYPE 12
 
+#ifdef WIN32
+// System TTS on Windows
+// moving C++ functions to this generic space.
+#include <sapi.h>
+#include <sphelper.h>
+#endif
+
 /* these strings are not seen by users */
 /* they are returned by Sword in module->Type() */
 #define TEXT_MODS "Biblical Texts"
@@ -145,6 +152,18 @@ const char *main_get_language_map(const char *language);
 char **main_get_module_language_list(void);
 void main_init_language_map(void);
 void main_devotional_button_clicked(gint direction);
+
+#ifdef WIN32
+// System TTS for Windows
+// Moved here from src/gtk/utilities.c.
+
+extern void* tts_handle;
+void WindowsInitSystemTTS(void);
+void WindowsStopSystemTTS(void);
+gboolean WindowsSystemSpeak(gchar *text, int length);
+void WindowsStopReading(void);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/main/sword.h
+++ b/src/main/sword.h
@@ -157,6 +157,7 @@ void main_devotional_button_clicked(gint direction);
 // System TTS for Windows
 // Moved here from src/gtk/utilities.c.
 
+#include <windows.h>
 extern void* tts_handle;
 void WindowsInitSystemTTS(void);
 void WindowsStopSystemTTS(void);

--- a/src/main/sword.h
+++ b/src/main/sword.h
@@ -50,14 +50,6 @@ extern "C" {
 #define DIALOG_SEARCH_PREVIEW_TYPE 11
 #define PRAYERLIST_TYPE 12
 
-#ifdef WIN32
-// System TTS on Windows
-// moving C++ functions to this generic space.
-#include <windows.h>
-#include <sapi.h>
-#include <sphelper.h>
-#endif
-
 /* these strings are not seen by users */
 /* they are returned by Sword in module->Type() */
 #define TEXT_MODS "Biblical Texts"

--- a/src/main/sword.h
+++ b/src/main/sword.h
@@ -53,6 +53,7 @@ extern "C" {
 #ifdef WIN32
 // System TTS on Windows
 // moving C++ functions to this generic space.
+#include <windows.h>
 #include <sapi.h>
 #include <sphelper.h>
 #endif
@@ -157,7 +158,6 @@ void main_devotional_button_clicked(gint direction);
 // System TTS for Windows
 // Moved here from src/gtk/utilities.c.
 
-#include <windows.h>
 extern void* tts_handle;
 void WindowsInitSystemTTS(void);
 void WindowsStopSystemTTS(void);


### PR DESCRIPTION
Previous failed effort to bring in system speech support in Windows was flawed, consequent to introducing C++ code into utilities.c. This was previously "#if 0" into oblivion, just so that other work could proceed.
This update moves the C++ constructs to src/main/sword.cc with gateway calls from functions in utilities.c. More #include files were required; additional linkage -lsapi was needed; type errors in utf8→utf16 conversion were fixed.