### PR TITLE
fix: prevent stack-buffer overflow on malformed URLs in main_url_handler

### DIFF
--- a/src/main/url.cc
+++ b/src/main/url.cc
@@ -890,6 +890,10 @@ gint main_url_handler(const gchar *url, gboolean clicked)
 		GString *tmpstr = g_string_new(NULL);
 
 		place = (char *)strchr(url, '?'); // url's beginning, as-is.
+		if (!place) {
+			g_string_free(tmpstr, TRUE);
+			return 0;
+		}
 		strncpy(tmpbuf, url, (++place) - url);
 		tmpbuf[place - url] = '\0';
 		tmpstr = g_string_append(tmpstr, tmpbuf);


### PR DESCRIPTION
In `main_url_handler()`, when a URL containing `passagestudy.jsp` or `xiphos.url` lacks a `?` character (i.e., has no query string), `strchr(url, '?')` returns NULL. The subsequent `++place` triggers undefined behavior, and `strncpy` writes with an effectively random length, overflowing the stack buffer `tmpbuf[1023]`.

Added a NULL check for `place` before use. If no `?` is found, the allocated `GString` is freed and the handler returns early.