### PR TITLE
fix: prevent URL parameter injection in user annotation links

### DIFF
--- a/src/main/display.cc
+++ b/src/main/display.cc
@@ -1610,13 +1610,16 @@ GTKChapDisp::display(SWModule &imodule)
 
 		// insert the userfootnote reference
 		if (e) {
+			gchar *escaped_value = g_uri_escape_string(
+				e->annotation->str, NULL, TRUE);
 			buf = g_strdup_printf("<span class=\"word\">"
 					      "<a href=\"passagestudy.jsp?action=showUserNote&"
 					      "module=%s&passage=%s&value=%s\"><small>"
 					      "<sup>*u</sup></small></a></span>&nbsp;",
 					      settings.MainWindowModule,
 					      (char *)key->getShortText(),
-					      e->annotation->str);
+					      escaped_value);
+			g_free(escaped_value);
 			swbuf.append(buf);
 			g_free(buf);
 		}
@@ -2048,13 +2051,16 @@ DialogChapDisp::display(SWModule &imodule)
 
 		// insert the userfootnote reference
 		if (e) {
+			gchar *escaped_value = g_uri_escape_string(
+				e->annotation->str, NULL, TRUE);
 			buf = g_strdup_printf("<span class=\"word\">"
 					      "<a href=\"passagestudy.jsp?action=showUserNote&"
 					      "module=%s&passage=%s&value=%s\">"
 					      "<small><sup>*u</sup></small></a></span> ",
 					      /*xxx*/ settings.MainWindowModule,
 					      (char *)key->getShortText(),
-					      e->annotation->str);
+					      escaped_value);
+			g_free(escaped_value);
 			swbuf.append(buf);
 			g_free(buf);
 		}


### PR DESCRIPTION
User annotation content (`e->annotation->str`) was being interpolated directly into the `value=` query parameter of the `passagestudy.jsp` URL in both `GTKChapDisp::display()` and `DialogChapDisp::display()` without URL encoding.

While basic HTML characters like `<`, `>`, `"` were escaped, URI-significant characters such as `&`, `=`, `#`, `+`, and `%` passed through unmodified. A crafted annotation like `&module=EvilMod&passage=EvilRef` could inject arbitrary URL parameters.

Applied `g_uri_escape_string()` to the annotation value before embedding it into the href attribute in both locations.