### PR TITLE
fix: replace fixed 1023-byte stack buffer with GString in main_url_handler

### DIFF
--- a/src/main/url.cc
+++ b/src/main/url.cc
@@ -886,7 +886,6 @@ gint main_url_handler(const gchar *url, gboolean clicked)
 
 		// another minor nightmare: re-encode / and : in hex.
 		gchar *place;
-		gchar tmpbuf[1023];
 		GString *tmpstr = g_string_new(NULL);
 
 		place = (char *)strchr(url, '?'); // url's beginning, as-is.
@@ -894,9 +893,8 @@ gint main_url_handler(const gchar *url, gboolean clicked)
 			g_string_free(tmpstr, TRUE);
 			return 0;
 		}
-		strncpy(tmpbuf, url, (++place) - url);
-		tmpbuf[place - url] = '\0';
-		tmpstr = g_string_append(tmpstr, tmpbuf);
+		++place;
+		tmpstr = g_string_append_len(tmpstr, url, place - url);
 		for (/* */; *place; ++place) {
 			switch (*place) {
 			case '/':


### PR DESCRIPTION
The URL handler for passagestudy.jsp-style URLs used a fixed 1023-byte
stack buffer (tmpbuf) with strncpy to extract the portion of the URL
before '?'. When the URL prefix before '?' exceeds 1022 characters,
strncpy fills the buffer without null termination, and the subsequent
null-byte write at tmpbuf[place - url] writes past the boundary.

Replace with dynamic GString allocation via g_string_append_len.

Commit adf7ae7f upstream added a null-pointer check for the result of
strchr(url, '?'), which is important but does not address the
fixed-buffer overflow. This fix replaces the stack buffer entirely.