### PR TITLE
fix: escape ampersand and apostrophe in annotation content to prevent stored XSS

### DIFF
--- a/src/main/display.cc
+++ b/src/main/display.cc
@@ -139,18 +139,20 @@ using namespace std;
 // user annotation cache filling.
 //
 
-#define NUM_REPLACE 4
+#define NUM_REPLACE 6
 
 struct replace
 {
 	gchar c;
 	gchar *s;
 } replacement[NUM_REPLACE] = {
-      // < and > must be first.
+      // & must be first to avoid double-encoding
+      {'&', (gchar *)"&amp;"},
       {'<', (gchar *)"&lt;"},
       {'>', (gchar *)"&gt;"},
       {'\n', (gchar *)"<br />"},
       {'"', (gchar *)"&quot;"},
+      {'\'', (gchar *)"&apos;"},
 };
 
 // a macro to substitute the visually ugly presentation below.


### PR DESCRIPTION
The annotation rendering code only replaced <, >, \n, and " with HTML
entities. The ampersand was not escaped, enabling an entity encoding
bypass: an attacker could enter e.g. &#60; which libxml2 would store
as &amp;#60; and decode back to &#60; on retrieval, allowing arbitrary
HTML injection.

Add &amp; (must be first to prevent double-encoding of &lt; etc.) and
&apos; to the replacement list. NUM_REPLACE goes from 4 to 6.