### PR TITLE
fix: escape special_anchor in HtmlOutput JS string literal

### DIFF
--- a/src/gtk/utilities.c
+++ b/src/gtk/utilities.c
@@ -1299,11 +1299,21 @@ HtmlOutput(char *text, GtkWidget *gtkText, MOD_FONT *mf, char *anchor)
 		len -= offset;
 
 		// now write the javascript snippet.
+		// escape the anchor for safe interpolation into a JS
+		// string literal.  special_anchor can originate from
+		// untrusted BibleSync navigation packets whose ref
+		// field carries the '#' fragment; without escaping a
+		// crafted value can break out of the string and inject
+		// script into the WebKit view.
+		const gchar *raw_anchor =
+		    (settings.special_anchor ? settings.special_anchor : anchor);
+		gchar *esc_anchor = g_strescape(raw_anchor, NULL);
 		buf =
 		    g_strdup_printf("<script type=\"text/javascript\" language=\"javascript\">"
 				    " window.onload = function () { window.location.hash = \"%s\"; }"
 				    " </script>",
-				    (settings.special_anchor ? settings.special_anchor : anchor));
+				    esc_anchor);
+		g_free(esc_anchor);
 		XIPHOS_HTML_WRITE(html, buf, strlen(buf));
 		g_free(buf);
 	}


### PR DESCRIPTION
HtmlOutput() in src/gtk/utilities.c interpolates settings.special_anchor into a JavaScript string literal inside a <script> tag via g_strdup_printf("window.location.hash = \"%s\"") with no escaping.

special_anchor is set in sword_uri() (src/main/url.cc:759) from the '#' or '!' fragment of sword:// URLs. These URLs are constructed from untrusted BibleSync navigation packets at biblesync_glue.cc:179, where a LAN peer controls the bible and ref fields directly from the UDP packet.

A crafted ref containing #"alert(1);}// breaks out of the JS string literal and executes arbitrary script in the JS-enabled WebKit2 view with file:// origin, when a user has BibleSync enabled.

The fix escapes the anchor value with g_strescape() before interpolation into the script tag, neutralizing backslash, double-quote, and other JS string literal metacharacters. The unescaped value is still used for XIPHOS_HTML_JUMP_TO_ANCHOR which handles it as an HTML anchor name, not executable code.