### PR TITLE
fix: replace strcpy with g_strlcpy for module_name in sidebar

### DIFF
--- a/src/main/sidebar.cc
+++ b/src/main/sidebar.cc
@@ -165,14 +165,16 @@ void main_display_verse_list_in_sidebar(gchar *key,
 		list_of_verses = NULL;
 	}
 
-	strcpy(settings.sb_search_mod, module_name);
+	g_strlcpy(settings.sb_search_mod, module_name,
+		  sizeof(settings.sb_search_mod));
 
 	model =
 	    gtk_tree_view_get_model(GTK_TREE_VIEW(sidebar.results_list));
 	list_store = GTK_LIST_STORE(model);
 	gtk_list_store_clear(list_store);
 
-	strcpy(sidebar.mod_name, module_name);
+	g_strlcpy(sidebar.mod_name, module_name,
+		  sizeof(sidebar.mod_name));
 
 	if (!strncmp(verse_list, "See ", 4))
 		verse_list += 4;


### PR DESCRIPTION
main_display_verse_list_in_sidebar() in src/main/sidebar.cc copies module_name into two fixed 80-byte buffers (settings.sb_search_mod[80] and sidebar.mod_name[80]) using strcpy() with no length check.

When BibleSync navigation takes the indirect path (unknown module name, multi-verse reference, or user preference for indirect navigation), the bible field from the UDP packet is passed directly as module_name at biblesync_glue.cc:184. A bible field exceeding 80 bytes overflows both global buffers, corrupting adjacent fields in the SETTINGS and SIDEBAR structs.

The fix replaces both strcpy() calls with g_strlcpy(), which always null-terminates and never writes more than the specified buffer size.