### PR TITLE
fix: prevent </script> breakout in HtmlOutput anchor JS literal

### DIFF
--- a/src/gtk/utilities.c
+++ b/src/gtk/utilities.c
@@ -1304,16 +1304,28 @@ HtmlOutput(char *text, GtkWidget *gtkText, MOD_FONT *mf, char *anchor)
 		// untrusted BibleSync navigation packets whose ref
 		// field carries the '#' fragment; without escaping a
 		// crafted value can break out of the string and inject
-		// script into the WebKit view.
+		// script into the WebKit view.  g_strescape escapes
+		// backslash, double-quote, and C0 control bytes but
+		// leaves '<', '>', and '/' untouched, so a value of
+		// "</script><script>PAYLOAD</script>" would end the
+		// inline <script> block and start a new one with
+		// attacker-controlled contents.  Substitute '</' with
+		// '<\/' (OWASP recommendation) to neutralise the
+		// breakout.
 		const gchar *raw_anchor =
 		    (settings.special_anchor ? settings.special_anchor : anchor);
 		gchar *esc_anchor = g_strescape(raw_anchor, NULL);
+		gchar *safe_anchor = g_strdup(esc_anchor);
+		gchar *q;
+		for (q = safe_anchor; (q = strstr(q, "</")) != NULL; q += 2)
+			q[1] = '\\';
+		g_free(esc_anchor);
 		buf =
 		    g_strdup_printf("<script type=\"text/javascript\" language=\"javascript\">"
 				    " window.onload = function () { window.location.hash = \"%s\"; }"
 				    " </script>",
-				    esc_anchor);
-		g_free(esc_anchor);
+				    safe_anchor);
+		g_free(safe_anchor);
 		XIPHOS_HTML_WRITE(html, buf, strlen(buf));
 		g_free(buf);
 	}


### PR DESCRIPTION
`g_strescape()` escapes backslash, double-quote, and C0 control bytes but leaves `<`, `>`, and `/` untouched, so a sword:// fragment of `</script><script>PAYLOAD</script>` passes through unchanged when interpolated into the inline `<script>` block in `HtmlOutput()`. WebKit's HTML parser ends the `<script>` block at the literal `</script>` and starts a new `<script>PAYLOAD</script>` block, which executes arbitrary JavaScript in the `file://` origin that `wk_html_set_base_uri()` hardcodes.

The fragment can originate from any BibleSync UDP multicast peer on the LAN (`biblesync_glue.cc:179` constructs the sword:// URL from peer-supplied `bible` and `ref`), from `argv[1]`, or from a sword:// href click inside a malicious SWORD module.

Substitute `</` with `<\/` in the already-escaped anchor (OWASP recommendation) so the HTML parser can no longer see the end of the script block. `g_strescape` is kept in place to also handle the backslash-and-quote break-out case from #1337.

A self-contained reproducer is in `poc/reproducer.c` in this branch: it shows that `g_strescape("</script><script>alert(1)</script>")` returns the input unchanged.

Follow-up to #1337.
