### PR TITLE
url: restrict clicked-link fallthrough to http/https URIs

### DIFF
--- a/src/main/url.cc
+++ b/src/main/url.cc
@@ -1063,8 +1063,17 @@ gint main_url_handler(const gchar *url, gboolean clicked)
 			g_free(passage);
 
 		g_string_free(tmpstr, TRUE);
-	} else if (clicked)
-		xiphos_open_default(url);
+	} else if (clicked) {
+		/* Only allow http:// and https:// URIs through the system
+		 * URI handler.  Bible/commentary/dictionary module content
+		 * is rendered HTML that is not otherwise sanitized, so an
+		 * attacker-controlled module could embed a link with a
+		 * dangerous scheme (file://, etc.) to disclose local files
+		 * or otherwise abuse the system's default URI handler. */
+		if (g_str_has_prefix(url, "http://") ||
+		    g_str_has_prefix(url, "https://"))
+			xiphos_open_default(url);
+	}
 
 #undef HAS_URL_PARAM
 


### PR DESCRIPTION
Bible, commentary, and dictionary module content is rendered as HTML by
SWORD's render filters and loaded into the WebKit view essentially
unmodified; there is no sanitization of <a href> values anywhere in the
render/display pipeline.

When a clicked link's URL doesn't match one of Xiphos's internal schemes
(sword://, bible://, passagestudy.jsp, xiphos.url), main_url_handler()
falls through to xiphos_open_default(), which calls
gtk_show_uri_on_window()/ShellExecuteW() on the raw URL with no scheme
check and no user confirmation. A malicious or compromised module
repository could embed a link such as

  <a href="file:///home/user/.ssh/id_rsa">click here</a>

in a commentary or dictionary entry; clicking it opens the local file with
the desktop's default handler for that file, without any warning.

This restricts the fallthrough to http:// and https:// URIs, which are the
only schemes legitimate module content should need for external links.
Other callers of xiphos_open_default() (About/help/mailing-list/bug-report
menu items) are unaffected.