### PR TITLE
percent-encode clipboard selection in biblemap URL

### DIFF
--- a/src/gtk/menu_popup.c
+++ b/src/gtk/menu_popup.c
@@ -1308,9 +1308,11 @@ G_MODULE_EXPORT void on_lookup_google_activate(GtkMenuItem *menuitem,
 	if ((dict_key == NULL) || (*dict_key == '\0')) {
 		gui_generic_warning("No selection made");
 	} else {
+		gchar *enc_key = g_uri_escape_string(dict_key, NULL, FALSE);
 		gchar *showstr =
-		    g_strconcat("http://www.biblemap.org/#", dict_key, NULL);
+		    g_strconcat("http://www.biblemap.org/#", enc_key, NULL);
 		xiphos_open_default(showstr);
+		g_free(enc_key);
 		g_free(showstr);
 	}
 	g_free(dict_key);


### PR DESCRIPTION
The "Open in Bible Map" action in the context menu builds a URL by
concatenating the clipboard selection into a fragment:

http://www.biblemap.org/#<selection>

The selection is not percent-encoded, so characters like spaces, #, &,
or newlines alter the URL structure passed to the system browser. A
second # in the selection hijacks the fragment portion.

The selection is now escaped with g_uri_escape_string() before being
inserted into the URL.
