### PR TITLE
Fix navigation not working when the active verse has no text

### DIFF
--- a/src/gtk/navbar_versekey.c
+++ b/src/gtk/navbar_versekey.c
@@ -387,7 +387,6 @@ static void on_button_history_back_clicked(GtkButton *button, gpointer user_data
 
 static void on_entry_activate(GtkEntry *entry, gpointer user_data)
 {
-	char *rawtext;
 	const gchar *gkey, *buf = gtk_entry_get_text(entry);
 
 	if (buf == NULL)
@@ -396,15 +395,6 @@ static void on_entry_activate(GtkEntry *entry, gpointer user_data)
 	if ((settings.special_anchor = strchr(buf, '#')) || /* thml */
 	    (settings.special_anchor = strchr(buf, '!')))   /* osisref */
 		*settings.special_anchor = '\0';
-
-	rawtext =
-	    main_get_raw_text(navbar_versekey.module_name->str,
-			      (gchar *)buf);
-	if (!rawtext || (rawtext && (strlen(rawtext) < 2))) {
-		gtk_entry_set_text(entry, navbar_versekey.key->str);
-		g_free(rawtext);
-		return;
-	}
 
 	gkey =
 	    main_get_valid_key(settings.MainWindowModule, (gchar *)buf);
@@ -416,8 +406,10 @@ static void on_entry_activate(GtkEntry *entry, gpointer user_data)
 
 	if (settings.special_anchor)
 		*settings.special_anchor = '#'; /* put it back. */
-	if (gkey == NULL)
+	if (gkey == NULL) {
+		gtk_entry_set_text(entry, navbar_versekey.key->str);
 		return;
+	}
 
 	gchar *url = g_strdup_printf("sword:///%s%s", gkey,
 				     (settings.special_anchor ? settings.special_anchor : ""));


### PR DESCRIPTION
## Summary

Xiphos would not work navigation (dropdown menus, spin arrows, and the lookup entry) whenever the target verse had no text in the active module. The display stayed stuck on the previously shown reference, nothing updated, and no error was shown to the user.

## Root cause

In `on_entry_activate()` (`src/gtk/navbar_versekey.c`), a key was treated as invalid if `main_get_raw_text()` returned fewer than 2 characters:

```c
rawtext = main_get_raw_text(navbar_versekey.module_name->str, (gchar *)buf);
if (!rawtext || (rawtext && (strlen(rawtext) < 2))) {
    gtk_entry_set_text(entry, navbar_versekey.key->str);
    g_free(rawtext);
    return;
}
```

This conflates two different things:
- whether the reference is *structurally valid* for the module's versification (already correctly checked right after, via `main_get_valid_key()` / `main_is_Bible_key()`)
- whether the module *happens to have text* for that specific verse

A reference can be perfectly valid while having no text (sparse/partial module, a verse intentionally left blank, etc.). BibleTime handles this correctly and simply shows an empty page. Xiphos, instead, aborted navigation entirely and got stuck.

## Reproduction

1. Take any Bible module and blank out the text of verse 1 of some chapter (e.g. 1 Kings 5:1).
2. Try to navigate to that chapter, via the dropdown menu, the spin arrows, or by typing the reference directly.
3. Navigation silently fails: the navbar stays on the previous reference.

## Fix

Removed the text-emptiness check. Key validity is now determined solely by `main_get_valid_key()` / `main_is_Bible_key()`, consistent with the rest of the function.

## Testing

Manually verified: blanking verse 1 of a chapter previously froze navigation to that chapter entirely. After this fix, navigation works normally and an empty verse is displayed as expected, without affecting navigation to subsequent verses/chapters.