### PR TITLE
fix #930 add context menu option under Lookup selection -> Translate selection.

### DIFF
--- a/src/gtk/menu_popup.c
+++ b/src/gtk/menu_popup.c
@@ -1281,41 +1281,79 @@ G_MODULE_EXPORT void on_use_current_dictionary_activate(GtkMenuItem *
 
 /******************************************************************************
  * Name
- *   on_lookup_google_activate
+ *   on_lookup_biblemap_activate
  *
  * Synopsis
  *   #include "gui/menu_popup.h"
  *
  * Description
- *   offer mouse-swept selection as a google maps browser reference.
+ *   offer mouse-swept selection as a biblemap browser reference.
  *
  * Return value
  *   void
  */
 
-G_MODULE_EXPORT void on_lookup_google_activate(GtkMenuItem *menuitem,
-					       gpointer user_data)
+G_MODULE_EXPORT void on_lookup_biblemap_activate(GtkMenuItem *menuitem,
+						 gpointer user_data)
 {
-	gchar *dict_key;
+	GtkWidget *html_widget = _get_html();
+	GdkDisplay *display = gtk_widget_get_display(html_widget);
 
-	XIPHOS_HTML_COPY_SELECTION(_get_html());
-	gtk_editable_select_region((GtkEditable *)widgets.entry_dict, 0,
-				   -1);
-	gtk_editable_paste_clipboard((GtkEditable *)widgets.entry_dict);
-	dict_key =
-	    g_strdup(gtk_editable_get_chars((GtkEditable *)widgets.entry_dict, 0, -1));
+	GtkClipboard *clipboard =
+		gtk_clipboard_get_for_display(display, GDK_SELECTION_PRIMARY);
 
-	if ((dict_key == NULL) || (*dict_key == '\0')) {
-		gui_generic_warning("No selection made");
-	} else {
-		gchar *enc_key = g_uri_escape_string(dict_key, NULL, FALSE);
-		gchar *showstr =
-		    g_strconcat("http://www.biblemap.org/#", enc_key, NULL);
+	gchar *text = gtk_clipboard_wait_for_text(clipboard);
+	int len = (text ? strlen(text) : 0);
+
+	if (text && len && *text) {
+		gchar *enc_key = g_uri_escape_string(text, NULL, FALSE);
+		gchar *showstr = g_strconcat("http://www.biblemap.org/#", enc_key, NULL);
 		xiphos_open_default(showstr);
 		g_free(enc_key);
 		g_free(showstr);
-	}
-	g_free(dict_key);
+	} else
+		gui_generic_warning("No selection made");
+}
+
+/******************************************************************************
+ * Name
+ *   on_translate_activate
+ *
+ * Synopsis
+ *   #include "gui/menu_popup.h"
+ *
+ * Description
+ *   offer mouse-swept selection as a google translation request.
+ *
+ * Return value
+ *   void
+ */
+
+G_MODULE_EXPORT void on_translate_activate(GtkMenuItem *menuitem,
+					   gpointer user_data)
+{
+	GtkWidget *html_widget = _get_html();
+	GdkDisplay *display = gtk_widget_get_display(html_widget);
+
+	GtkClipboard *clipboard =
+		gtk_clipboard_get_for_display(display, GDK_SELECTION_PRIMARY);
+
+	gchar *text = gtk_clipboard_wait_for_text(clipboard);
+	int len = (text ? strlen(text) : 0);
+
+	if (text && len && *text) {
+		gchar *enc_key = g_uri_escape_string(text, NULL, FALSE);
+		gchar *showstr = g_strconcat("https://translate.google.com/?sl=auto&tl=",
+					     (sword_locale ? sword_locale : ""),
+					     "&op=translate",
+					     "&text=",
+					     enc_key,
+					     NULL);
+		xiphos_open_default(showstr);
+		g_free(enc_key);
+		g_free(showstr);
+	} else
+		gui_generic_warning("No selection made");
 }
 
 /******************************************************************************

--- a/src/gui/menu_popup.h
+++ b/src/gui/menu_popup.h
@@ -115,8 +115,10 @@ void on_display_chapter_heading_activate(GtkMenuItem *menuitem,
 					 gpointer user_data);
 void on_use_current_dictionary_activate(GtkMenuItem *menuitem,
 					gpointer user_data);
-void on_lookup_google_activate(GtkMenuItem *menuitem,
-			       gpointer user_data);
+void on_lookup_biblemap_activate(GtkMenuItem *menuitem,
+				 gpointer user_data);
+void on_translate_activate(GtkMenuItem *menuitem,
+			   gpointer user_data);
 void on_rename_perscomm_activate(GtkMenuItem *menuitem,
 				 gpointer user_data);
 void on_dump_perscomm_activate(GtkMenuItem *menuitem,

--- a/ui/xi-menus-popup.gtkbuilder
+++ b/ui/xi-menus-popup.gtkbuilder
@@ -801,19 +801,29 @@
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Use Current Dictionary</property>
+                <property name="label" translatable="yes">_Use Current Dictionary</property>
                 <property name="use_underline">True</property>
                 <signal name="activate" handler="on_use_current_dictionary_activate" swapped="no"/>
               </object>
             </child>
             <child>
-              <object class="GtkMenuItem" id="lookup_google">
+              <object class="GtkMenuItem" id="translate">
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Browse in BibleMap.org</property>
+                <property name="label" translatable="yes">_Translate selection</property>
                 <property name="use_underline">True</property>
-                <signal name="activate" handler="on_lookup_google_activate" swapped="no"/>
+                <signal name="activate" handler="on_translate_activate" swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuItem" id="lookup_biblemap">
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">_Browse in BibleMap.org</property>
+                <property name="use_underline">True</property>
+                <signal name="activate" handler="on_lookup_biblemap_activate" swapped="no"/>
               </object>
             </child>
             <child>

--- a/ui/xi-menus.glade
+++ b/ui/xi-menus.glade
@@ -1255,18 +1255,27 @@
 	  <child>
 	    <widget class="GtkMenuItem" id="use_current_dictionary">
 	      <property name="visible">True</property>
-	      <property name="label" translatable="yes">Use Current Dictionary</property>
+	      <property name="label" translatable="yes">_Use Current Dictionary</property>
 	      <property name="use_underline">True</property>
 	      <signal name="activate" handler="on_use_current_dictionary_activate" last_modification_time="Sat, 28 Feb 2009 04:28:54 GMT"/>
 	    </widget>
 	  </child>
 
 	  <child>
-	    <widget class="GtkMenuItem" id="lookup_google">
+	    <widget class="GtkMenuItem" id="translate">
 	      <property name="visible">True</property>
-	      <property name="label" translatable="yes">Browse in BibleMap.org</property>
+	      <property name="label" translatable="yes">_Translate selection</property>
 	      <property name="use_underline">True</property>
-	      <signal name="activate" handler="on_lookup_google_activate" last_modification_time="Tue, 23 Jun 2009 11:14:54 GMT"/>
+	      <signal name="activate" handler="on_translate_activate" last_modification_time="Tue, 23 Jun 2009 11:14:54 GMT"/>
+	    </widget>
+	  </child>
+
+	  <child>
+	    <widget class="GtkMenuItem" id="lookup_biblemap">
+	      <property name="visible">True</property>
+	      <property name="label" translatable="yes">_Browse in BibleMap.org</property>
+	      <property name="use_underline">True</property>
+	      <signal name="activate" handler="on_lookup_biblemap_activate" last_modification_time="Tue, 23 Jun 2009 11:14:54 GMT"/>
 	    </widget>
 	  </child>
 


### PR DESCRIPTION
Right-click menu gains an entry at the top for translating the mouse-swept selection.
Also some noticeable cleanup in the similar biblemap lookup code, the 2 functions are nearly identical other than url construction.
(At this time, biblemap lookup is useless, the website is not active.)