### PR TITLE
Fix set name key conversion on set switch

### DIFF
--- a/src/gtk/navbar_versekey_parallel.c
+++ b/src/gtk/navbar_versekey_parallel.c
@@ -818,8 +818,9 @@ static void on_parallel_set_activate(GtkMenuItem *item, gpointer user_data)
 	settings.parallel_set_current = g_strdup(name);
 	xml_set_or_create_value("modules", "parallel_set_current", name);
 	/* update Sets button label */
-	gchar *label = g_strdup_printf(_("Set: %s"), name);
-	gtk_button_set_label(GTK_BUTTON(navbar_parallel.button_sets), label);
+	gchar *display = key_to_name(name);
+	gchar *label = g_strdup_printf(_("Set: %s"), display);
+	g_free(display);	gtk_button_set_label(GTK_BUTTON(navbar_parallel.button_sets), label);
 	g_free(label);
 	xml_save_settings_doc(settings.fnconfigure);
 	
@@ -863,7 +864,9 @@ static void on_parallel_sets_button_clicked(GtkWidget *widget,
 	names = g_strsplit(settings.parallel_set_names, ",", -1);
 
 	for (gint i = 0; names[i]; ++i) {
-		item = gtk_menu_item_new_with_label(names[i]);
+		gchar *display = key_to_name(names[i]);
+		item = gtk_menu_item_new_with_label(display);
+		g_free(display);
 		g_signal_connect(G_OBJECT(item), "activate",
 				 G_CALLBACK(on_parallel_set_activate),
 				 g_strdup(names[i]));
@@ -1017,8 +1020,14 @@ GtkWidget *gui_navbar_versekey_parallel_new(void)
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(navbar_parallel.button_sync),
 				     settings.linkedtabs);
 	/* parallel sets button */
-	gchar *sets_label = g_strdup_printf(_("Set: %s"),
-	    settings.parallel_set_current ? settings.parallel_set_current : "—");
+	gchar *sets_label;
+	if (settings.parallel_set_current && *settings.parallel_set_current) {
+		gchar *display = key_to_name(settings.parallel_set_current);
+		sets_label = g_strdup_printf(_("Set: %s"), display);
+		g_free(display);
+	} else {
+		sets_label = g_strdup_printf(_("Set: %s"), "—");
+	}
 	GtkWidget *button_sets = gtk_button_new_with_label(sets_label);
 	g_free(sets_label);
 	gtk_widget_set_tooltip_text(button_sets, _("Switch parallel module set"));

--- a/src/gtk/preferences_dialog.c
+++ b/src/gtk/preferences_dialog.c
@@ -3358,16 +3358,18 @@ static void on_parallel_sets_combo_changed(GtkComboBox *combo,
 
 	/* the active set is saved automatically by on_parallel_reordered */
 	/* load the new set */
-	gchar **modules = get_parallel_set(name);
+	gchar *key = name_to_key(name);
+	gchar **modules = get_parallel_set(key);
+	g_free(key);
 	if (modules) {
 		g_strfreev(settings.parallel_list);
 		settings.parallel_list = modules;
 	}
-
 	if (settings.parallel_set_current)
 		g_free(settings.parallel_set_current);
-	settings.parallel_set_current = name;
-	xml_set_or_create_value("modules", "parallel_set_current", name);
+	settings.parallel_set_current = name_to_key(name);
+	xml_set_or_create_value("modules", "parallel_set_current", settings.parallel_set_current);
+	g_free(name);
 	xml_save_settings_doc(settings.fnconfigure);
 	
 	/* refresh listview */

--- a/src/gtk/preferences_dialog.c
+++ b/src/gtk/preferences_dialog.c
@@ -3276,48 +3276,61 @@ static void on_parallel_sets_combo_changed(GtkComboBox *combo,
 
 		if (gtk_dialog_run(GTK_DIALOG(dialog)) == GTK_RESPONSE_OK) {
 			const gchar *setname = gtk_entry_get_text(GTK_ENTRY(entry));
-			if (setname && *setname) {
-				/* build new set_names */
+			/* validate: no spaces or XML-special characters */
+			gboolean valid = setname && *setname;
+			/* convert display name to XML key */
+			gchar *setkey = valid ? name_to_key(setname) : NULL;
+			if (!valid || !setkey || !*setkey) {
+				GtkWidget *err = gtk_message_dialog_new(
+				    GTK_WINDOW(dialog),
+				    GTK_DIALOG_MODAL,
+				    GTK_MESSAGE_ERROR,
+				    GTK_BUTTONS_OK,
+				    _("Please enter a valid set name."));
+				gtk_dialog_run(GTK_DIALOG(err));
+				gtk_widget_destroy(err);
+				g_free(setkey);
+			} else {
+				/* build new set_names using the key */
 				gchar *new_names;
 				if (settings.parallel_set_names && *settings.parallel_set_names)
 					new_names = g_strdup_printf("%s,%s",
-					    settings.parallel_set_names, setname);
+					    settings.parallel_set_names, setkey);
 				else
-					new_names = g_strdup(setname);
-
+					new_names = g_strdup(setkey);
 				g_free(settings.parallel_set_names);
 				settings.parallel_set_names = new_names;
 				xml_set_or_create_value("modules", "parallel_set_names", new_names);
-
 				/* save current parallel_list as the new set */
 				if (settings.parallel_list)
-					save_parallel_set(setname, settings.parallel_list);
-
+					save_parallel_set(setkey, settings.parallel_list);
 				/* switch to new set */
 				g_free(settings.parallel_set_current);
-				settings.parallel_set_current = g_strdup(setname);
-				xml_set_or_create_value("modules", "parallel_set_current", setname);
+				settings.parallel_set_current = g_strdup(setkey);
+				xml_set_or_create_value("modules", "parallel_set_current", setkey);
 				xml_save_settings_doc(settings.fnconfigure);
-				
 				/* rebuild combo */
 				g_signal_handlers_block_by_func(
 				    parallel_select.sets_combo,
 				    on_parallel_sets_combo_changed, NULL);
-				#if GTK_CHECK_VERSION(3, 0, 0)
-					gtk_combo_box_text_remove_all(
-						GTK_COMBO_BOX_TEXT(parallel_select.sets_combo));
-				#else
-					{
-						GtkTreeModel *m = gtk_combo_box_get_model(
-							GTK_COMBO_BOX(parallel_select.sets_combo));
-						gtk_list_store_clear(GTK_LIST_STORE(m));
-					}
-				#endif
+#if GTK_CHECK_VERSION(3, 0, 0)
+				gtk_combo_box_text_remove_all(
+				    GTK_COMBO_BOX_TEXT(parallel_select.sets_combo));
+#else
+				{
+					GtkTreeModel *m = gtk_combo_box_get_model(
+					    GTK_COMBO_BOX(parallel_select.sets_combo));
+					gtk_list_store_clear(GTK_LIST_STORE(m));
+				}
+#endif
 				gchar **names = g_strsplit(settings.parallel_set_names, ",", -1);
-				for (gint i = 0; names[i]; ++i)
+				for (gint i = 0; names[i]; ++i) {
+					gchar *display = key_to_name(names[i]);
 					gtk_combo_box_text_append_text(
 					    GTK_COMBO_BOX_TEXT(parallel_select.sets_combo),
-					    names[i]);
+					    display);
+					g_free(display);
+				}
 				g_strfreev(names);
 				gtk_combo_box_text_append_text(
 				    GTK_COMBO_BOX_TEXT(parallel_select.sets_combo),
@@ -3325,7 +3338,7 @@ static void on_parallel_sets_combo_changed(GtkComboBox *combo,
 				/* select the new set */
 				gchar **all = g_strsplit(settings.parallel_set_names, ",", -1);
 				for (gint i = 0; all[i]; ++i) {
-					if (g_strcmp0(all[i], setname) == 0) {
+					if (g_strcmp0(all[i], setkey) == 0) {
 						gtk_combo_box_set_active(
 						    GTK_COMBO_BOX(parallel_select.sets_combo), i);
 						break;
@@ -3335,6 +3348,7 @@ static void on_parallel_sets_combo_changed(GtkComboBox *combo,
 				g_signal_handlers_unblock_by_func(
 				    parallel_select.sets_combo,
 				    on_parallel_sets_combo_changed, NULL);
+				g_free(setkey);
 			}
 		}
 		gtk_widget_destroy(dialog);
@@ -3717,8 +3731,11 @@ static void create_preferences_dialog(void)
 		/* populate with existing set names */
 		if (settings.parallel_set_names && *settings.parallel_set_names) {
 			gchar **names = g_strsplit(settings.parallel_set_names, ",", -1);
-			for (gint i = 0; names[i]; ++i)
-				gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo), names[i]);
+			for (gint i = 0; names[i]; ++i) {
+				gchar *display = key_to_name(names[i]);
+				gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(combo), display);
+				g_free(display);
+			}
 			g_strfreev(names);
 		}
 		/* add "New set..." entry */

--- a/src/main/settings.c
+++ b/src/main/settings.c
@@ -425,7 +425,6 @@ void load_settings_structure(void)
 	/* parallel sets */
 	settings.parallel_set_names = xml_get_value("modules", "parallel_set_names");
 	settings.parallel_set_current = xml_get_value("modules", "parallel_set_current");
-	settings.parallel_set_current = xml_get_value("modules", "parallel_set_current");
 	/* load active parallel set at startup */
 	if (settings.parallel_set_current && *settings.parallel_set_current) {
 		char **set_modules = get_parallel_set(settings.parallel_set_current);
@@ -1279,4 +1278,20 @@ void save_parallel_set(const gchar *name, gchar **modules)
 	g_free(key);
 	g_free(value);
 }
+char *name_to_key(const char *name)
+{
+	char *key = g_strdup(name);
+	for (char *p = key; *p; ++p)
+		if (*p == ' ')
+			*p = '_';
+	return key;
+}
 
+char *key_to_name(const char *key)
+{
+	char *name = g_strdup(key);
+	for (char *p = name; *p; ++p)
+		if (*p == '_')
+			*p = ' ';
+	return name;
+}

--- a/src/main/settings.h
+++ b/src/main/settings.h
@@ -248,6 +248,8 @@ extern SETTINGS settings;
 int settings_init(int argc, char **argv, int new_configs,
 		  int new_bookmarks);
 void load_settings_structure(void);
+char *name_to_key(const char *name);
+char *key_to_name(const char *key);
 char **get_parallel_set(const char *name);
 void save_parallel_set(const char *name, char **modules);
 


### PR DESCRIPTION


When switching sets via the ComboBox, the displayed name (with spaces)
was being stored directly in settings.xml instead of the XML key
(with underscores), causing a mismatch on next startup.

Apply name_to_key() before storing parallel_set_current and before
calling get_parallel_set() when switching sets.