### PR TITLE
Test building Windows without GTK2

### DIFF
--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -95,6 +95,7 @@ if (WIN32)
     install(FILES
       ${SYS_ROOT_BIN}/libglade-2.0-0.dll
       ${SYS_ROOT_BIN}/libgailutil-18.dll
+      ${SYS_ROOT_BIN}/libgdk-win32-2.0-0.dll
       ${SYS_ROOT_BIN}/libgtk-win32-2.0-0.dll
       ${SYS_ROOT_BIN}/libjavascriptcoregtk-1.0-0.dll
       ${SYS_ROOT_BIN}/libwebkitgtk-1.0-0.dll
@@ -178,7 +179,6 @@ if (WIN32)
     ${SYS_ROOT_BIN}/libpng16-16.dll
     ${SYS_ROOT_BIN}/libgdk_pixbuf-2.0-0.dll
     ${SYS_ROOT_BIN}/libgdk-3-0.dll
-    ${SYS_ROOT_BIN}/libgdk-win32-2.0-0.dll
     ${SYS_ROOT_BIN}/libgio-2.0-0.dll
     ${SYS_ROOT_BIN}/libglib-2.0-0.dll
     ${SYS_ROOT_BIN}/libgmodule-2.0-0.dll

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -121,6 +121,7 @@ if (WIN32)
       ${SYS_ROOT_BIN}/libgtk-3-0.dll
       ${SYS_ROOT_BIN}/libjavascriptcoregtk-3.0-0.dll
       ${SYS_ROOT_BIN}/libwebkitgtk-3.0-0.dll
+      ${SYS_ROOT_BIN}/libepoxy-0.dll
       DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT binaries
       )

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -5,8 +5,8 @@ VOLUME /source
 # Installs dependencies once and for all
 RUN dnf -y update --refresh && \
     dnf -y install autoconf automake cmake git fpc gettext glib2-devel itstool libxslt libX11-devel make subversion yelp-tools zip && \
-    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk3 mingw32-xz && \
-    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk3 mingw64-xz && \
+    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk3 mingw32-xz && \
+    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk3 mingw64-xz && \
     dnf clean all
 
 ADD build_sword.sh /build_sword.sh

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -5,8 +5,8 @@ VOLUME /source
 # Installs dependencies once and for all
 RUN dnf -y update --refresh && \
     dnf -y install autoconf automake cmake git fpc gettext glib2-devel itstool libxslt libX11-devel make subversion yelp-tools zip && \
-    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk mingw32-xz && \
-    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk mingw64-xz && \
+    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk3 mingw32-xz && \
+    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk3 mingw64-xz && \
     dnf clean all
 
 ADD build_sword.sh /build_sword.sh

--- a/win32/xc-xiphos-win.sh
+++ b/win32/xc-xiphos-win.sh
@@ -81,7 +81,7 @@ trap 'exit 1' ERR
 function do_build {
     bits="${1}"
     mkdir -p win${bits} && cd win${bits}
-    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTKTVEDITOR=ON -DWEBKIT1=ON -DGTK3=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
+    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTKTVEDITOR=ON -DWEBKIT1=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
     make VERBOSE=1
     make mhelp-epub-{C,fa,fr,it} package
     cd ..

--- a/win32/xc-xiphos-win.sh
+++ b/win32/xc-xiphos-win.sh
@@ -81,7 +81,7 @@ trap 'exit 1' ERR
 function do_build {
     bits="${1}"
     mkdir -p win${bits} && cd win${bits}
-    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTK2=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
+    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTKTVEDITOR=ON -DWEBKIT1=ON -DGTK3=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
     make VERBOSE=1
     make mhelp-epub-{C,fa,fr,it} package
     cd ..


### PR DESCRIPTION
* Move to long-deprecated WEBKIT1 backend, but at least it gives us a
  shot at GTK3
* Use GTKTVEDITOR in the builds

TODO: Something is still pulling in gtk-2 in the images. That should be
sorted out before everything is fully merged
