### PR TITLE
Parallel sets: fix set name key conversion on set switch

### DIFF
--- a/src/gtk/preferences_dialog.c
+++ b/src/gtk/preferences_dialog.c
@@ -3358,16 +3358,18 @@ static void on_parallel_sets_combo_changed(GtkComboBox *combo,
 
 	/* the active set is saved automatically by on_parallel_reordered */
 	/* load the new set */
-	gchar **modules = get_parallel_set(name);
+	gchar *key = name_to_key(name);
+	gchar **modules = get_parallel_set(key);
+	g_free(key);
 	if (modules) {
 		g_strfreev(settings.parallel_list);
 		settings.parallel_list = modules;
 	}
-
 	if (settings.parallel_set_current)
 		g_free(settings.parallel_set_current);
-	settings.parallel_set_current = name;
-	xml_set_or_create_value("modules", "parallel_set_current", name);
+	settings.parallel_set_current = name_to_key(name);
+	xml_set_or_create_value("modules", "parallel_set_current", settings.parallel_set_current);
+	g_free(name);
 	xml_save_settings_doc(settings.fnconfigure);
 	
 	/* refresh listview */


### PR DESCRIPTION
This PR contains a single fix following #1356 (already merged).

### Problem

When switching between parallel sets via the ComboBox in Preferences,
the displayed name (with spaces, e.g. "No OSHB") was being stored
directly in `settings.xml` as `parallel_set_current` instead of the
XML key form (with underscores, e.g. `No_OSHB`). This caused a
mismatch on next startup since the key lookup would fail.

### Fix

Apply `name_to_key()` before storing `parallel_set_current` and before
calling `get_parallel_set()` when switching sets.

### Note

PR #1357 is superseded by this PR. The first commit
of #1357 (XML-invalid character fix) was already merged as #1356 by
you.