### PR TITLE
Fix  Windows GTK3 build

### DIFF
--- a/src/editor/gtktextview_editor.c
+++ b/src/editor/gtktextview_editor.c
@@ -523,7 +523,7 @@ _load_file(EDITOR *e, const gchar *filename)
 		g_error_free(error);
 	}
 
-	_load_text_into_buffer(e, text);
+	_load_text_into_buffer(e, text ? text : "");
 	if (text)
 		g_free(text);
 }
@@ -1383,7 +1383,7 @@ editor_load_note(EDITOR *e, const gchar *module_name, const gchar *key)
 	}
 
 	text = main_get_raw_text((gchar *)e->module, (gchar *)e->key);
-	_load_text_into_buffer(e, text);
+	_load_text_into_buffer(e, text ? text : "");
 	if (text)
 		g_free(text);
 

--- a/src/gtk/dictlex.c
+++ b/src/gtk/dictlex.c
@@ -621,16 +621,6 @@ GtkWidget *gui_create_devotional_pane(void)
 
 	widgets.entry_devotional = gtk_entry_new();
 	gtk_entry_set_max_length(GTK_ENTRY(widgets.entry_devotional), 5);
-#ifdef _WIN32
-	/* Windows: GtkCalendar is broken — show the MM.DD text entry instead */
-	gtk_entry_set_width_chars(GTK_ENTRY(widgets.entry_devotional), 6);
-	gtk_widget_set_tooltip_text(widgets.entry_devotional, _("Date MM.DD"));
-	gtk_widget_show(widgets.entry_devotional);
-	gtk_box_pack_start(GTK_BOX(hbox), widgets.entry_devotional, FALSE, FALSE, 0);
-	widgets.button_devotional_date = NULL;
-	widgets.popover_devotional     = NULL;
-	widgets.calendar_devotional    = NULL;
-#else
 	widgets.button_devotional_date = gtk_button_new_with_label("--");
 	gtk_widget_show(widgets.button_devotional_date);
 	gtk_widget_set_tooltip_text(widgets.button_devotional_date,
@@ -650,7 +640,6 @@ GtkWidget *gui_create_devotional_pane(void)
 	gtk_container_add(GTK_CONTAINER(widgets.popover_devotional),
                       widgets.calendar_devotional);
 #endif
-#endif /* _WIN32 */
 
 	/* prev button */
 	button_prev = gtk_button_new();
@@ -698,12 +687,10 @@ GtkWidget *gui_create_devotional_pane(void)
 #endif
 
 	/* signaux */
-#ifndef _WIN32
 	g_signal_connect(G_OBJECT(widgets.button_devotional_date), "clicked",
 					 G_CALLBACK(on_button_devotional_date_clicked), NULL);
 	g_signal_connect(G_OBJECT(widgets.calendar_devotional), "day-selected-double-click",
 					 G_CALLBACK(on_calendar_day_selected), NULL);
-#endif 
 	g_signal_connect(G_OBJECT(widgets.entry_devotional), "activate",
 					 G_CALLBACK(devot_key_entry_changed), NULL);
 	g_signal_connect((gpointer)button_prev, "clicked",

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -172,6 +172,29 @@ int main(int argc, char *argv[])
 					       //g_getenv("ALLUSERSPROFILE"),
 					       strings[0]),
 		 FALSE);
+	/*
+	 * GTK3 needs to find its compiled GSettings schemas (used
+	 * internally e.g. by GtkFileChooserButton in the Preferences
+	 * dialog) and its icon theme (hicolor/Adwaita). Neither is
+	 * discovered automatically in this MinGW cross-compiled build,
+	 * so point GLib/GTK at them explicitly.
+	 *
+	 * This must happen AFTER the SWORD_PATH computation above, since
+	 * SWORD_PATH depends on g_get_system_data_dirs(), which itself
+	 * reads XDG_DATA_DIRS — setting it earlier changed where
+	 * SWORD_PATH pointed and moved installed modules unexpectedly.
+	 * We also append to, rather than replace, any existing
+	 * XDG_DATA_DIRS value so other consumers aren't disrupted.
+	 */
+	gchar *share_dir = xiphos_win32_get_subdir("share");
+	g_setenv("GSETTINGS_SCHEMA_DIR",
+		g_build_filename(share_dir, "glib-2.0", "schemas", NULL),
+		TRUE);
+	const gchar *existing_xdg_data_dirs = g_getenv("XDG_DATA_DIRS");
+	gchar *new_xdg_data_dirs = existing_xdg_data_dirs
+		? g_strdup_printf("%s;%s", share_dir, existing_xdg_data_dirs)
+		: share_dir;
+	g_setenv("XDG_DATA_DIRS", new_xdg_data_dirs, TRUE);
 
 	/*it is necessary to explicitly set LANG, because we depend on that
 	   variable to set the SWORD locale */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -166,25 +166,31 @@ int main(int argc, char *argv[])
 	   been set by some other program or set manually. In the case that
 	   it hasn't been set, it is set to the localized equivalent of
 	   C:/Documents and Settings/All Users/Application Data/Sword */
-	const gchar *const *strings;
-	strings = g_get_system_data_dirs();
-	g_setenv("SWORD_PATH", g_strdup_printf("%s\\Sword",
-					       //g_getenv("ALLUSERSPROFILE"),
-					       strings[0]),
+	/*
+	 * NOTE: SWORD_PATH is deliberately computed WITHOUT calling
+	 * g_get_system_data_dirs(). That function caches its result on
+	 * first call for the lifetime of the process (documented GLib
+	 * behavior), and GTK's internal icon theme lookup relies on the
+	 * same cached call. Calling it here — before or after setting
+	 * XDG_DATA_DIRS below — would poison that cache and make our
+	 * XDG_DATA_DIRS override invisible to GTK's icon search, which
+	 * is what caused icons to go missing again after a previous fix
+	 * to this same block. ALLUSERSPROFILE/PROGRAMDATA give the same
+	 * directory g_get_system_data_dirs() would have on Windows by
+	 * default, without touching the cache.
+	 */
+	const gchar *programdata = g_getenv("PROGRAMDATA");
+	if (!programdata)
+		programdata = g_getenv("ALLUSERSPROFILE");
+	g_setenv("SWORD_PATH", g_strdup_printf("%s\\Sword", programdata),
 		 FALSE);
 	/*
 	 * GTK3 needs to find its compiled GSettings schemas (used
 	 * internally e.g. by GtkFileChooserButton in the Preferences
 	 * dialog) and its icon theme (hicolor/Adwaita). Neither is
 	 * discovered automatically in this MinGW cross-compiled build,
-	 * so point GLib/GTK at them explicitly.
-	 *
-	 * This must happen AFTER the SWORD_PATH computation above, since
-	 * SWORD_PATH depends on g_get_system_data_dirs(), which itself
-	 * reads XDG_DATA_DIRS — setting it earlier changed where
-	 * SWORD_PATH pointed and moved installed modules unexpectedly.
-	 * We also append to, rather than replace, any existing
-	 * XDG_DATA_DIRS value so other consumers aren't disrupted.
+	 * so point GLib/GTK at them explicitly. Safe to do here since
+	 * nothing above has called g_get_system_data_dirs() yet.
 	 */
 	gchar *share_dir = xiphos_win32_get_subdir("share");
 	g_setenv("GSETTINGS_SCHEMA_DIR",

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -95,6 +95,7 @@ if (WIN32)
     install(FILES
       ${SYS_ROOT_BIN}/libglade-2.0-0.dll
       ${SYS_ROOT_BIN}/libgailutil-18.dll
+      ${SYS_ROOT_BIN}/libgdk-win32-2.0-0.dll
       ${SYS_ROOT_BIN}/libgtk-win32-2.0-0.dll
       ${SYS_ROOT_BIN}/libjavascriptcoregtk-1.0-0.dll
       ${SYS_ROOT_BIN}/libwebkitgtk-1.0-0.dll
@@ -120,6 +121,7 @@ if (WIN32)
       ${SYS_ROOT_BIN}/libgtk-3-0.dll
       ${SYS_ROOT_BIN}/libjavascriptcoregtk-3.0-0.dll
       ${SYS_ROOT_BIN}/libwebkitgtk-3.0-0.dll
+      ${SYS_ROOT_BIN}/libepoxy-0.dll
       DESTINATION ${CMAKE_INSTALL_BINDIR}
       COMPONENT binaries
       )
@@ -178,7 +180,6 @@ if (WIN32)
     ${SYS_ROOT_BIN}/libpng16-16.dll
     ${SYS_ROOT_BIN}/libgdk_pixbuf-2.0-0.dll
     ${SYS_ROOT_BIN}/libgdk-3-0.dll
-    ${SYS_ROOT_BIN}/libgdk-win32-2.0-0.dll
     ${SYS_ROOT_BIN}/libgio-2.0-0.dll
     ${SYS_ROOT_BIN}/libglib-2.0-0.dll
     ${SYS_ROOT_BIN}/libgmodule-2.0-0.dll
@@ -279,6 +280,36 @@ if (WIN32)
   install(FILES
     ${PROJECT_SOURCE_DIR}/pixmaps/xiphos.svg
     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps
+    COMPONENT data
+    )
+
+  # install icon theme (hicolor + adwaita, for GTK3 symbolic icons)
+  install(DIRECTORY
+    ${SYS_ROOT_SHARE}/icons
+    DESTINATION ${CMAKE_INSTALL_DATADIR}
+    COMPONENT data
+    )
+
+  # install gdk-pixbuf loaders (needed to render icons/pixbufs at runtime)
+  install(DIRECTORY
+    ${SYS_ROOT_LIB}/gdk-pixbuf-2.0
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT binaries
+    )
+
+  # install GSettings schemas (required by GtkFileChooserButton and others,
+  # otherwise fatal GLib-GIO-ERROR "No GSettings schemas are installed")
+  install(DIRECTORY
+    ${SYS_ROOT_SHARE}/glib-2.0/schemas
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0
+    COMPONENT data
+    )
+
+  # compile the schemas at build time (produces gschemas.compiled)
+  find_program(GLIB_COMPILE_SCHEMAS glib-compile-schemas)
+  install(CODE "
+    execute_process(COMMAND \${GLIB_COMPILE_SCHEMAS} \"\${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas\")
+    "
     COMPONENT data
     )
 

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -5,8 +5,8 @@ VOLUME /source
 # Installs dependencies once and for all
 RUN dnf -y update --refresh && \
     dnf -y install autoconf automake cmake git fpc gettext glib2-devel itstool libxslt libX11-devel make subversion yelp-tools zip && \
-    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk3 mingw32-xz && \
-    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk3 mingw64-xz && \
+    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk3 mingw32-xz && \
+    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk3 mingw64-xz && \
     dnf clean all
 
 ADD build_sword.sh /build_sword.sh

--- a/win32/Dockerfile
+++ b/win32/Dockerfile
@@ -5,8 +5,8 @@ VOLUME /source
 # Installs dependencies once and for all
 RUN dnf -y update --refresh && \
     dnf -y install autoconf automake cmake git fpc gettext glib2-devel itstool libxslt libX11-devel make subversion yelp-tools zip && \
-    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk mingw32-xz && \
-    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk mingw64-xz && \
+    dnf -y install mingw32-biblesync mingw32-clucene mingw32-curl mingw32-gcc mingw32-gdb mingw32-libgnurx mingw32-gettext mingw32-gtk3 mingw32-icu mingw32-libglade2 mingw32-libidn mingw32-libsoup mingw32-libtiff mingw32-minizip mingw32-nsis mingw32-webkitgtk3 mingw32-xz && \
+    dnf -y install mingw64-biblesync mingw64-clucene mingw64-curl mingw64-gcc mingw64-gdb mingw64-libgnurx mingw64-gettext mingw64-gtk3 mingw64-icu mingw64-libglade2 mingw64-libidn mingw64-libsoup mingw64-libtiff mingw64-minizip mingw32-nsis mingw64-webkitgtk3 mingw64-xz && \
     dnf clean all
 
 ADD build_sword.sh /build_sword.sh

--- a/win32/xc-xiphos-win.sh
+++ b/win32/xc-xiphos-win.sh
@@ -81,7 +81,7 @@ trap 'exit 1' ERR
 function do_build {
     bits="${1}"
     mkdir -p win${bits} && cd win${bits}
-    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTKTVEDITOR=ON -DWEBKIT1=ON -DGTK3=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
+    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTKTVEDITOR=ON -DWEBKIT1=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
     make VERBOSE=1
     make mhelp-epub-{C,fa,fr,it} package
     cd ..

--- a/win32/xc-xiphos-win.sh
+++ b/win32/xc-xiphos-win.sh
@@ -81,7 +81,7 @@ trap 'exit 1' ERR
 function do_build {
     bits="${1}"
     mkdir -p win${bits} && cd win${bits}
-    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTK2=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
+    cmake -DCMAKE_TOOLCHAIN_FILE=/usr/share/mingw/toolchain-mingw${bits}.cmake -DGTKTVEDITOR=ON -DWEBKIT1=ON -DGTK3=ON -DCONSOLE=OFF "${XIPHOS_PATH}"
     make VERBOSE=1
     make mhelp-epub-{C,fa,fr,it} package
     cd ..


### PR DESCRIPTION
## Windows GTK3 build (`test/windows-build-gtk3`)

### Starting point
After moving to GTK3/GtkBuilder/WebKit1, two blocking issues showed up at runtime on Windows (tested via Wine): icons weren't rendering, and opening the Preferences dialog silently crashed the app. Several other issues surfaced and were fixed along the way.

---

### 1. Missing icons & Preferences crash

**Diagnosis:** The cause: `win32/CMakeLists.txt` installed the GTK3 DLLs but not three runtime resources GTK3 needs:
1. The system icon theme (hicolor/Adwaita)
2. `gdk-pixbuf` loaders
3. Compiled GSettings schemas (used internally by `GtkFileChooserButton` in Preferences)

Missing 3 caused a **fatal** `GLib-GIO-ERROR: No GSettings schemas are installed`, killing the process on Preferences open.

**Fix (`win32/CMakeLists.txt`):** added `install()` rules for the icon theme, pixbuf loaders, and compiled schemas.

**Follow-up bug:** even with resources bundled, GTK/GLib didn't discover them automatically at runtime — needed `GSETTINGS_SCHEMA_DIR` and `XDG_DATA_DIRS` set explicitly. Added this in `src/main/main.c`, computed dynamically via `xiphos_win32_get_subdir("share")`.

**Regression 1:** setting `XDG_DATA_DIRS` before the existing `g_get_system_data_dirs()` call (used for `SWORD_PATH`) redirected installed modules into the Xiphos install dir instead of the system location.

**Regression 2 (root cause, fixed properly):** `g_get_system_data_dirs()` **caches its result for the life of the process** on first call (documented GLib behavior). Calling it for `SWORD_PATH` — before *or* after setting `XDG_DATA_DIRS` — poisons that cache, and GTK's internal icon theme lookup (which uses the same cached call) never sees our override. Fixed by computing `SWORD_PATH` from `PROGRAMDATA`/`ALLUSERSPROFILE` directly instead of calling `g_get_system_data_dirs()` at all, so `XDG_DATA_DIRS`/`GSETTINGS_SCHEMA_DIR` can be set freely before `gtk_init()` without anything having poisoned the cache first.

**Result:** icons render correctly, Preferences opens without crashing, modules stay in the correct location. ✅

---

### 2. Editor ("studypad") crash — fatal `strdup`

**Symptom:** `xiphos va s'arrêter sur une erreur strdup` in `gtktextview_editor.c:469`, building `"<html><body>%s</body></html>"`.

**Diagnosis:** On glibc (Linux), `printf("%s", NULL)` prints `"(null)"` and continues; on MSVCRT/UCRT (Windows/MinGW), passing `NULL` to `%s` aborts the process immediately. Two call sites to `_load_text_into_buffer()` could pass `NULL` text:
- `_load_file()` — when reading a studypad file fails
- `editor_load_note()` — when a note/bookmark has no content yet (e.g. brand-new note)

A third call site already guarded with `text ? text : ""`; applied the same pattern to the two unguarded ones.

**Result:** editor/studypad no longer crashes. ✅

---

### 3. Daily devotional: enable GTK3 calendar on Windows

**Context:** a `#ifdef _WIN32` fallback showed a manual MM.DD text entry instead of the `GtkCalendar` popover, with the comment "Windows: GtkCalendar is broken." This was presumably true under the old GTK2/WebKit1 build.

**Fix:** removed the Windows-specific fallback in `src/gtk/dictlex.c` (widget creation `#ifdef _WIN32/#else/#endif`, and the `#ifndef _WIN32` guard around the calendar/button signal connects), so Windows now uses the same calendar+popover UI as Linux. The `entry_devotional` widget is kept unshown as internal date storage, matching prior Linux behavior.

**Result:** calendar popover opens and date selection works. ✅

**Known remaining cosmetic issue:** the devotional date button shows as a blank/gray box — no visible label text (not even the initial `"--"`) — though it's fully functional (clicking still opens the popover correctly, and the box size is fixed regardless of window resizing, ruling out a layout/reflow issue). This looks like a GTK3 "wimp" theme-engine text rendering quirk under Wine specifically, rather than an app bug — **pending confirmation on native Windows** (not yet tested outside Wine).