### PR TITLE
Fix crash of Paralle view tab

### DIFF
--- a/src/gtk/navbar_versekey_parallel.c
+++ b/src/gtk/navbar_versekey_parallel.c
@@ -325,7 +325,10 @@ static void on_entry_activate(GtkEntry *entry, gpointer user_data)
 
 	navbar_parallel.valid_key = TRUE;
 	main_navbar_versekey_set(navbar_parallel, settings.cvparallel);
-	main_update_parallel_page_detached();
+	if (settings.dockedInt)
+		main_update_parallel_page();
+	else
+		main_update_parallel_page_detached();
 	if (sync_on) {
 		const gchar *main_window_url =
 		    g_strdup_printf("sword:///%s%s",


### PR DESCRIPTION
I think the double navigation bar is an XML file issue; I cleared it out, and now there's just one bar again. The fix for the crash seems pretty basic to me—I ran about twenty tests locally and in a VM, and I didn't experience any crashes; before, it would crash after just two tests. I hope that's it!