### PR TITLE
Balance chapter HTML and fix intro-material italics leaking into text

### DIFF
--- a/src/main/display.cc
+++ b/src/main/display.cc
@@ -95,6 +95,7 @@ A { text-decoration:none } \
 body { background-color:%s; color:%s; -webkit-column-count: %d ; margin-top: 0.1cm ; %s } \
 td { %s } \
 .introMaterial { font-style: italic; } \
+.introMaterial h2.chapterHeader { font-style: normal; } \
 a:link{ color:%s } %s %s \
 .tagcolor a:link{ color:inherit !important } \
 h3 { font-style: %s } --> \
@@ -1221,8 +1222,33 @@ GTKChapDisp::introMaterial(SWModule &imodule, int thisChapter)
 		}
 	}
 
-	if (started_intro)
+	if (started_intro) {
+		/* Issue #921: SWORD's OSIS filter can emit an opening
+		 * <div type="subSection" ...> for a section heading
+		 * without a matching closing </div> anywhere in the
+		 * fetched "verse 0" text (the section's eID/closing tag
+		 * apparently falls elsewhere, outside what we retrieve
+		 * here). Left unbalanced, our own closing </div> below
+		 * only closes the innermost open <div>, leaving
+		 * class="introMaterial" (and its CSS font-style: italic)
+		 * open around the rest of the chapter. Force-balance
+		 * before closing our own wrapper. */
+		gint div_opens = 0, div_closes = 0;
+		const gchar *scan = intro->str;
+		while ((scan = strstr(scan, "<div"))) {
+			div_opens++;
+			scan += 4;
+		}
+		scan = intro->str;
+		while ((scan = strstr(scan, "</div>"))) {
+			div_closes++;
+			scan += 6;
+		}
+		for (; div_closes < div_opens; div_closes++)
+			g_string_append(intro, "</div>");
+
 		g_string_append(intro, "</div>");		// finish what we started.
+	}
 
 	key->setAutoNormalize(oldAutoNorm);
 

--- a/src/webkit/wk-html.c
+++ b/src/webkit/wk-html.c
@@ -36,6 +36,9 @@
 #include "wk-html.h"
 #include "marshal.h"
 
+#include <libxml/HTMLparser.h>
+#include <libxml/HTMLtree.h>
+
 #include "gui/dictlex.h"
 #include "main/sword.h"
 
@@ -343,6 +346,52 @@ void wk_html_printf(WkHtml *html, char *format, ...)
 	g_free(string);
 }
 
+/* Issue #921: balance/repair the final HTML before handing it to
+ * WebKit. Several code paths in src/main/display.cc can produce
+ * mismatched or overlapping tags (e.g. multi-chapter OSIS sections,
+ * or chapter intro material). Left as-is, WebKit's own HTML5 parser
+ * "adoption agency algorithm" silently fragments affected elements
+ * to recover, which was found to break keyboard caret navigation
+ * (Down/Page_Down) and let inline styles (e.g. italics) leak past
+ * their intended scope in some chapters.
+ *
+ * Parsing with HTML_PARSE_RECOVER and re-serializing gives WebKit a
+ * document that is already well-formed. On parse failure, the
+ * original content is returned unchanged. */
+static gchar *
+wk_html_sanitize(const gchar *raw, const gchar *mime)
+{
+	if (!raw)
+		return NULL;
+
+	if (!mime || !(strstr(mime, "html") != NULL))
+		return g_strdup(raw);
+
+	htmlDocPtr doc = htmlReadMemory(raw, (int)strlen(raw), NULL, "UTF-8",
+					HTML_PARSE_RECOVER |
+					    HTML_PARSE_NOERROR |
+					    HTML_PARSE_NOWARNING |
+					    HTML_PARSE_NONET);
+	if (!doc)
+		return g_strdup(raw);
+
+	xmlChar *out = NULL;
+	int out_len = 0;
+	htmlDocDumpMemory(doc, &out, &out_len);
+
+	gchar *result;
+	if (out && out_len > 0)
+		result = g_strndup((const gchar *)out, (gsize)out_len);
+	else
+		result = g_strdup(raw);
+
+	if (out)
+		xmlFree(out);
+	xmlFreeDoc(doc);
+
+	return result;
+}
+
 void wk_html_close(WkHtml *html)
 {
 	if (!html->priv->initialised) {
@@ -352,12 +401,11 @@ void wk_html_close(WkHtml *html)
 #endif
 	}
 
-
-
+	gchar *clean_content = wk_html_sanitize(html->priv->content, html->priv->mime);
 
 #ifdef USE_WEBKIT2
 	GBytes *html_bytes;
-	html_bytes = g_bytes_new(html->priv->content, strlen(html->priv->content));
+	html_bytes = g_bytes_new(clean_content, strlen(clean_content));
 
 	webkit_web_view_load_bytes(WEBKIT_WEB_VIEW(html),
 				   html_bytes,
@@ -368,11 +416,12 @@ void wk_html_close(WkHtml *html)
 	g_bytes_unref(html_bytes);
 #else
 	webkit_web_view_load_string(WEBKIT_WEB_VIEW(html),
-				    html->priv->content,
+				    clean_content,
 				    html->priv->mime,
 				    NULL, html->priv->base_uri);
 #endif
 
+	g_free(clean_content);
 	g_free(html->priv->content);
 	html->priv->content = NULL;
 	g_free(html->priv->mime);


### PR DESCRIPTION
Follow-up to #921: while chapter intro material (book/section headings) is meant to render in italics via ".introMaterial { font- style: italic; }", two related bugs let that styling — and malformed markup in general — leak into the rest of the chapter on modules with rich introductions (e.g. FreCrampon).

- GTKChapDisp::introMaterial() (src/main/display.cc): SWORD's OSIS filter can emit an opening <div type="subSection" ...> for a section heading with no matching closing </div> anywhere in the fetched text. Now counts <div>/</div> occurrences and appends any missing closing tags before closing our own wrapper, so the block is always self-balanced regardless of what the filter provides.

- wk_html_sanitize() (src/webkit/wk-html.c): parses the final assembled HTML with libxml2 (HTML_PARSE_RECOVER) and re-serializes it before handing it to WebKit, rather than letting WebKit's own parser silently repair mismatched tags unpredictably. General safety net for similar cases we may not have found yet.

- CSS: added ".introMaterial h2.chapterHeader { font-style: normal; }" so section/chapter titles stay upright — only the narrative intro text should be italic, not its headings.