### PR TITLE
Fix italics leak with per-fragment div-balancing

### DIFF
--- a/src/main/display.cc
+++ b/src/main/display.cc
@@ -1212,26 +1212,46 @@ GTKChapDisp::introMaterial(SWModule &imodule, int thisChapter)
 				started_intro = true;
 			}
 
-			g_string_append(intro,
-					(settings.imageresize
-					 ? AnalyzeForImageSize(buf, CURRENT_COLUMNS,
-							       GDK_WINDOW(gtk_widget_get_window(gtkText)))
-					 : buf));
+			/* Issue #921: SWORD's OSIS filter can emit an opening
+			 * <div type="subSection" ...> in this fragment with no
+			 * matching closing </div> here (its eID apparently falls
+			 * outside what we fetch for the chapter-0/thisChapter
+			 * "verse 0" text). Balance THIS fragment individually,
+			 * right where it is fetched -- rather than counting the
+			 * whole accumulated intro string and stacking corrections
+			 * at the very end, which was found to shift block-level
+			 * boundaries enough to break WebKit's column-break and
+			 * anchor-scroll positioning in multi-column, whole-book
+			 * rendering. Closing right next to this fragment's own
+			 * content keeps the correction local and minimal. */
+			{
+				gint div_opens = 0, div_closes = 0;
+				const gchar *scan = buf;
+				while ((scan = strstr(scan, "<div"))) {
+					div_opens++;
+					scan += 4;
+				}
+				scan = buf;
+				while ((scan = strstr(scan, "</div>"))) {
+					div_closes++;
+					scan += 6;
+				}
+
+				g_string_append(intro,
+						(settings.imageresize
+						 ? AnalyzeForImageSize(buf, CURRENT_COLUMNS,
+								       GDK_WINDOW(gtk_widget_get_window(gtkText)))
+						 : buf));
+
+				for (; div_closes < div_opens; div_closes++)
+					g_string_append(intro, "</div>");
+			}
+
 			g_string_append(intro, "<br />");
 			g_free(buf);
 		}
 	}
 
-	/* Issue #921: an earlier attempt balanced unclosed <div> tags
-	 * here by force-closing them before our own wrapper. That fixed
-	 * italics leaking past chapter intro material, but shifting
-	 * block-level closing boundaries at this exact spot was found to
-	 * break WebKit's column-break and anchor-scroll positioning in
-	 * multi-column layouts + whole-book rendering (reported by Karl,
-	 * reproducible with 4 columns). Reverted; italics leaking onto
-	 * verse text is instead handled defensively at the verse-text
-	 * level in RenderOneChapter(), which doesn't touch block
-	 * boundaries at all. */
 	if (started_intro)
 		g_string_append(intro, "</div>");		// finish what we started.
 


### PR DESCRIPTION
Third attempt at the introMaterial() italics leak (#921 follow-up).

Previous attempts each fixed the leak but caused a new regression:
- Balancing the whole accumulated intro string and stacking missing </div> closes at the very end (original #1385) shifted block-level boundaries enough to break WebKit's column-break and anchor-scroll positioning in multi-column, whole-book rendering (Karl, #1385 comments).
- Wrapping every verse's text in a defensive <span style="font-style: normal;"> (the fix for that regression, #1387) stopped italics bleeding onto verse text, but is suspected of interfering with WebKit's last-line detection for text-align: justify, producing over-justified lines (Karl, #1385 comments, reproducible with Justify margins + 4 columns + whole-book rendering; not yet reproduced locally on this end).

This attempt balances each fetched OSIS fragment (chapter 0 and/or thisChapter "verse 0" text) individually, right where it is fetched, instead of accumulating corrections at the end of the whole intro block. The missing closing tags land immediately next to their own content rather than stacked far from their opening, which should be far less disruptive to surrounding block structure. The verse-text wrapping span is removed entirely -- no longer needed, and no new element is introduced around verse text at all.

Local testing: italics stay confined to the chapter intro on modules with rich introductions (e.g. FreCrampon), and Karl's column/anchor scenario (4 columns, whole-book rendering, Deu 24:17) checks out. Could not reproduce the justification issue locally to verify the fix for it; requesting Karl test this branch before merge.